### PR TITLE
Refactoring from utils to mapper package

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.utils;
+package io.strimzi.kafka.bridge.mqtt.mapper;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -2,9 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.core;
-
-import io.strimzi.kafka.bridge.mqtt.utils.MappingRule;
+package io.strimzi.kafka.bridge.mqtt.mapper;
 
 import java.util.List;
 import java.util.ArrayList;

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapperTest.java
@@ -2,9 +2,8 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.core;
+package io.strimzi.kafka.bridge.mqtt.mapper;
 
-import io.strimzi.kafka.bridge.mqtt.utils.MappingRule;
 import org.junit.Test;
 
 import java.util.ArrayList;


### PR DESCRIPTION
The mapping logic is not just "utils".
This PR moves the `MappingRule` in a new `mapper` package together with the `MqttKafkaMapper` itself.
They deserve a dedicated package.