### PR TITLE
doc: add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Each mapping rule is a JSON object that contains two properties: `mqttTopic` and
   }
 ]
 ```
-The wildcard "#" represents one or more levels in the topic hierarchy. The wildcard "+" represents a single level in the topic hierarchy.
+The wildcard "#" represents one or more levels in the topic hierarchy. 
+The wildcard "+" represents a single level in the topic hierarchy.
 
 Let's go through each rule:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This project provides a software component which acts as a bridge between [MQTT 
 ### How it works
 
 To enable a seamless integration between MQTT and Kafka, the MQTT Bridge provides a way to map MQTT topics to Kafka topics. 
-This mapping is done using a set of predefined patterns and kafka topic templates. The MQTT Bridge uses these patterns to map MQTT topics to Kafka topics. 
+This mapping is done using a set of predefined patterns and Kafka topic templates.
+The MQTT Bridge uses these patterns to map MQTT topics to Kafka topics. 
 As a part of the bridge, a Kafka producer will be responsible for producing messages from the MQTT clients to the Kafka Cluster.
 
 ### Topic Mapping Rules (ToMaR)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The order in which the rules are defined is important. The MQTT Bridge will use 
 ### 2. MQTT Bridge Configuration
 
 The user can configure the MQTT Bridge using an `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge. 
-The MQTT bridge can be configured using the appropriate prefix. Example:
+The MQTT bridge can be configured using the appropriate prefix.
+Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The order in which the rules are defined is important. The MQTT Bridge will use 
 
 ### 2. MQTT Bridge Configuration
 
-The user can configure the MQTT Bridge using an `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge. 
+The user can configure the MQTT Bridge using an `application.properties` file.
+This section describes the configuration properties that can be used to configure the MQTT Bridge. 
 The MQTT bridge can be configured using the appropriate prefix.
 Example:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
 All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in which Kafka topic to produce this message.
-This Kafka topic is defined by a template, `kafka Topic template`.
+This Kafka topic is defined by a template, `Kafka Topic template`.
 However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka topic where the incoming message will be mapped to, known as `messages_default`.
 
 A valid ToMaR is a JSON file that contains an array of mapping rules. 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ All the incoming MQTT message's topic should match an `MQTT topic pattern` in th
 This Kafka topic is defined by a template, `kafka Topic template`.
 However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka topic where the incoming message will be mapped to, known as `messages_default`.
 
-A valid TOMAR is a JSON file that contains an array of mapping rules. Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
+A valid ToMaR is a JSON file that contains an array of mapping rules. 
+Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`.
+The following is an example of a valid TOMAR:
 
 ```json
 [

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 #### 1.2. Topic Mapping Rules(TOMAR)
 
-The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
+The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
 All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has a default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@
 
 This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
 
-### Running Tests
-
-```bash
-mvn clean test
-```
-
 ## MQTT bridge documentation
-
-This section provides information about the MQTT Bridge. It describes the MQTT Bridge, how it works, and how to configure it.
 
 ### 1. MQTT Bridge Overview
 
@@ -27,12 +19,9 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. 
-This Kafka topic is defined by a template, `kafka Topic template`. 
-However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has a default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
 
-A valid TOMAR is a JSON file that contains an array of mapping rules. 
-Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
+A valid TOMAR is a JSON file that contains an array of mapping rules. Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
 
 ```json
 [
@@ -50,48 +39,39 @@ Each mapping rule is a JSON object that contains two properties: `mqttTopic` and
   }
 ]
 ```
-The wildcard "#" represents one or more levels in the topic hierarchy. 
-The wildcard "+" represents a single level in the topic hierarchy.
 
-Let's go through each rule:
+The wildcard "#" represents one or more levels in the MQTT topic hierarchy. The wildcard "+" represents a single level in the MQTT topic hierarchy.
+It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
+
+Let's go through each rule to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
 1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
 
-    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". 
-    For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
 
 2. MQTT Topic: "sensors/#" -> Kafka Topic: "sensor_others"
 
-    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". 
-    For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
+    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
 
 3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
 
-    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". 
-    For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
+    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
 
-These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns.
-The MQTT Bridge uses these rules to map MQTT topics to Kafka topics. The order in which the rules are defined is important. 
-The MQTT Bridge will use the first rule that matches the MQTT topic. 
-For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. 
-If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
+These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns. The MQTT Bridge uses these rules to map MQTT topics to Kafka topics. 
+The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
 
 ### 2. MQTT Bridge Configuration
 
-The user can configure the MQTT Bridge using the `application.properties` file.
-This section describes the configuration properties that can be used to configure the MQTT Bridge.
+The user can configure the MQTT Bridge using an `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
 The MQTT bridge can be configured using the appropriate prefix. Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.
 - `kafka.` is the prefix used for Kafka configuration of the Bridge.
 
-### 2.1 Procedure to configure the MQTT Bridge
+A valid configuration file should look like this:
 
-1. Find the `application.properties` file in the `config` directory or create a new one.
-2. Edit the file to configure the MQTT Bridge.
-    A valid configuration file should look like this:
-    ```properties
+```properties
     # Bridge configuration
     bridge.id=my-bridge
     # MQTT configuration
@@ -99,17 +79,16 @@ The MQTT bridge can be configured using the appropriate prefix. Example:
     mqtt.server.port=1883
     # Kafka configuration
     kafka.bootstrap.servers=localhost:9092
-    ```
-3. Save the file.
+   ```
 
-The following table describes the configuration properties that can be used to configure the MQTT Bridge.
+The following table describes the configuration properties defined above.
 
-| Setting                        | Description                                     | Default        |
-| ------------------------------ | ----------------------------------------------- |----------------|
-| bridge.id                      | ID of the bridge                                | my-bridge      |
-| mqtt.server.host               | Host address of the MQTT server                 | localhost      |
-| mqtt.server.port               | Port number of the MQTT server                  | 1883           |
-| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092 |
+| Setting                 | Description                        | Default        |
+|-------------------------|------------------------------------|----------------|
+| bridge.id               | ID of the bridge                   | my-bridge      |
+| mqtt.server.host        | Host address of the MQTT server    | localhost      |
+| mqtt.server.port        | Port number of the MQTT server     | 1883           |
+| kafka.bootstrap.servers | Bootstrap servers for Apache Kafka | localhost:9092 |
 
 Other than the above properties, the user can also configure the bridge using environment variables.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Let's go through each rule to understand how the MQTT Bridge uses these rules to
 
     This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
 
-These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns. The MQTT Bridge uses these rules to map MQTT topics to Kafka topics. 
 The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
 
 ### 2. MQTT Bridge Configuration

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ A valid TOMAR is a JSON file that contains an array of mapping rules. Each mappi
 The wildcard "#" represents one or more levels in the MQTT topic hierarchy. The wildcard "+" represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
+The parts with curly braces in the MQTT topic pattern are called `placeholders`. The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.
+
 Let's go through each rule to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
 1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
@@ -62,7 +64,7 @@ The order in which the rules are defined is important. The MQTT Bridge will use 
 
 ### 2. MQTT Bridge Configuration
 
-The user can configure the MQTT Bridge using an `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
+The user can configure the MQTT Bridge using an `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge. 
 The MQTT bridge can be configured using the appropriate prefix. Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. 
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. 
+This Kafka topic is defined by a template, `kafka Topic template`. 
 However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
 
 A valid TOMAR is a JSON file that contains an array of mapping rules. 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka.
 
 
 #### 1.2.1 The MqttKafkaMapper
-This interface is responsible for mapping incoming MQTT topic to Kafka topic. How this mapping is should be made must be defined in the `Topic Mapping Rules(TOMAR)`.
+This interface is responsible for mapping incoming MQTT topic names to Kafka topic names. How this mapping is done must must be defined in the `Topic Mapping Rules(TOMAR)`.
 
 #### 1.2.2 Topic Mapping Rules(TOMAR)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The wildcard "#" represents one or more levels in the MQTT topic hierarchy.
 The wildcard "+" represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
-The parts with curly braces in the MQTT topic pattern are called `placeholders`. The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.
+The parts with curly braces in the MQTT topic pattern are called `placeholders`.
+The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.
 
 Let's go through each rule to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
 
-## MQTT bridge documentation
 
 ### 1. MQTT Bridge Overview
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The MQTT bridge can be configured using the appropriate prefix. Example:
 
 The following table describes the configuration properties that can be used to configure the MQTT Bridge.
 
-| Setting                        | Description                                     | Deafult           |
+| Setting                        | Description                                     | Default           |
 | ------------------------------ | ----------------------------------------------- |-------------------|
 | bridge.id                      | ID of the bridge                                | my-bridge         |
 | mqtt.server.host               | Host address of the MQTT server                 | localhost         |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Let's go through each rule to understand how the MQTT Bridge uses these rules to
 
 3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
 
-    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
+    This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`. 
+    For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
 
 The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This interface is responsible for mapping incoming MQTT topic to Kafka topic. Ho
 
 #### 1.2.2 Topic Mapping Rules(TOMAR)
 
-The TOMAR is a set of patterns the user provides, to which the MQTT Bridge will decide which Kafka topic to produce a message. 
+The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to.
 
 ##### 1.2.2.1 Usage/Examples

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
 
 
-### 1. MQTT Bridge Overview
+## MQTT Bridge Overview
 
 #### 1.1 How it works
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can use the MQTT bridge to take advantage of the benefits of both MQTT and K
 
 #### 1.2 How it works
 
-The MQTT Bridge is a netty-based MQTT server that is responsible for handling all the MQTT client connections and connections management and is responsible for all MQTT-based operations like QoS, error handling, and other capabilities Netty offers.
+The MQTT Bridge is a netty-based MQTT server that is responsible for handling all the MQTT client connections, connections management, and all MQTT-based operations like QoS, error handling, and other capabilities which Netty offers.
 
 The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka. 
 1. MQTT mapper: maps incoming MQTT topics to Kafka topics. 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To enable a seamless integration between MQTT and Kafka, the MQTT Bridge provide
 This mapping is done using a set of predefined patterns and kafka topic templates. The MQTT Bridge uses these patterns to map MQTT topics to Kafka topics. 
 As a part of the bridge, a Kafka producer will be responsible for producing messages from the MQTT clients to the Kafka Cluster.
 
-#### 1.2. Topic Mapping Rules(TOMAR)
+### Topic Mapping Rules (ToMaR)
 
 The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 # MQTT bridge for Apache Kafka®
 
-This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
+This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) 
+and an [Apache Kafka®](https://kafka.apache.org/) cluster.
 
 ## Running the bridge
 
@@ -21,37 +22,35 @@ Once your configuration is ready, start the bridge using:
 You can find more information about the topic mapping rules in the MQTT Bridge.
 
 ### Running Tests
+
 ```bash
 mvn clean test
 ```
 
 ## MQTT bridge documentation
 
+This section provides information about the MQTT Bridge. It describes the MQTT Bridge, how it works, and how to configure it.
+
 ### 1. MQTT Bridge Overview
-You can use the MQTT bridge to take advantage of the benefits of both MQTT and Kafka in data processing and IoT system scenarios.
 
-#### 1.1 General overview.
+#### 1.1 How it works
 
-#### 1.2 How it works
+To enable a seamless integration between MQTT and Kafka, the MQTT Bridge provides a way to map MQTT topics to Kafka topics. 
+This mapping is done using a set of predefined patterns and kafka topic templates. The MQTT Bridge uses these patterns to map MQTT topics to Kafka topics. 
+As a part of the bridge, a Kafka producer will be responsible for producing messages from the MQTT clients to the Kafka Cluster.
 
-The MQTT Bridge is a netty-based MQTT server that is responsible for handling all the MQTT client connections, connections management, and all MQTT-based operations like QoS, error handling, and other capabilities which Netty offers.
-
-The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka. 
-1. MQTT mapper: maps incoming MQTT topics to Kafka topics. 
-2. MQTT Bridge:  transforms the incoming MQTT payload to a valid Kafka record and then sends them to the appropriate Kafka topic using a Kafka Producer.
-
-
-#### 1.2.1 The MqttKafkaMapper
-This interface is responsible for mapping incoming MQTT topic names to Kafka topic names. How this mapping is done must must be defined in the `Topic Mapping Rules(TOMAR)`.
-
-#### 1.2.2 Topic Mapping Rules(TOMAR)
+#### 1.2. Topic Mapping Rules(TOMAR)
 
 The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
-A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to.
+A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which 
+Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. 
+However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka 
+topic where the incoming message will be mapped to, know as `messages_default`.
 
-##### 1.2.2.1 Usage/Examples
 A valid TOMAR is a JSON file that contains an array of mapping rules. 
 Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
+
 ```json
 [
   {
@@ -68,31 +67,47 @@ Each mapping rule is a JSON object that contains two properties: `mqttTopic` and
   }
 ]
 ```
+
 Let's go through each rule:
 
 1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
-    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". The wildcard "#" represents one or more levels in the topic hierarchy. For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+
+    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". 
+    The wildcard "#" represents one or more levels in the topic hierarchy. For example, if the MQTT topic is "building/A/room/1/floor/2", 
+    it will be mapped to the Kafka topic "building_A_room_1_floor_2".
 
 2. MQTT Topic: "sensors/#" -> Kafka Topic: "sensor_others"
 
-    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". The "#" wildcard matches any number of levels. For example, if the MQTT topic is "sensors/temperature/living-room", it will be mapped to the Kafka topic "sensor_others".
+    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". 
+    The "#" wildcard matches any number of levels. For example, if the MQTT topic is "sensors/temperature/living-room", 
+    it will be mapped to the Kafka topic "sensor_others".
 
 3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
 
-    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". The "+" wildcard matches a single level in the topic hierarchy. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
+    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". The "+" 
+    wildcard matches a single level in the topic hierarchy. For example, if the MQTT topic is "sensors/temperature/data", 
+    it will be mapped to the Kafka topic "sensor_data".
 
-These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns. The MQTT Bridge uses these rules to map MQTT topics to Kafka topics.
-The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", 
-it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
+These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns.
+The MQTT Bridge uses these rules to map MQTT topics to Kafka topics.
+The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. 
+For example, if the MQTT topic is "sensors/temperature/data", 
+it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined,
+the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
 
 ### 2. MQTT Bridge Configuration
-The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
+
+The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration 
+properties that can be used to configure the MQTT Bridge.
 The MQTT bridge can be configured using the appropriate prefix. Example:
+
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.
 - `kafka.` is the prefix used for Kafka configuration of the Bridge.
+
 ### 2.1 Procedure to configure the MQTT Bridge
-1. Find the `application.properties` file in the `config` directory.
+
+1. Find the `application.properties` file in the `config` directory or create a new one.
 2. Edit the file to configure the MQTT Bridge.
     A valid configuration file should look like this:
     ```properties
@@ -108,12 +123,12 @@ The MQTT bridge can be configured using the appropriate prefix. Example:
 
 The following table describes the configuration properties that can be used to configure the MQTT Bridge.
 
-| Setting                        | Description                                     | E.g. Value              |
-| ------------------------------ | ----------------------------------------------- |-------------------------|
-| bridge.id                      | ID of the bridge                                | my-bridge               |
-| mqtt.server.host               | Host address of the MQTT server                 | localhost(default)      |
-| mqtt.server.port               | Port number of the MQTT server                  | 1883(default)           |
-| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092(default) |
+| Setting                        | Description                                     | Deafult           |
+| ------------------------------ | ----------------------------------------------- |-------------------|
+| bridge.id                      | ID of the bridge                                | my-bridge         |
+| mqtt.server.host               | Host address of the MQTT server                 | localhost         |
+| mqtt.server.port               | Port number of the MQTT server                  | 1883(default)     |
+| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092    |
 
 Other than the above properties, the user can also configure the bridge using environment variables.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ You can use the MQTT bridge to take advantage of the benefits of both MQTT and K
 
 The MQTT Bridge is a netty-based MQTT server that is responsible for handling all the MQTT client connections and connections management and is responsible for all MQTT-based operations like QoS, error handling, and other capabilities Netty offers.
 
-The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka. The mapper maps incoming MQTT topics to Kafka topics. Once this mapping is completed, the MQTT Bridge will transform the incoming MQTT payload to a valid Kafka record and then send to the appropriate Kafka topic through the bridge kafka Producer.
+The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka. 
+1. MQTT mapper: maps incoming MQTT topics to Kafka topics. 
+2. MQTT Bridge:  transforms the incoming MQTT payload to a valid Kafka record and then sends them to the appropriate Kafka topic using a Kafka Producer.
+
 
 #### 1.2.1 The MqttKafkaMapper
 This interface is responsible for mapping incoming MQTT topic to Kafka topic. How this mapping is should be made must be defined in the `Topic Mapping Rules(TOMAR)`.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ A valid TOMAR is a JSON file that contains an array of mapping rules. Each mappi
     "kafkaTopic": "building_{building}_room_{room}"
   },
   {
-    "mqttTopic": "sensors/#",
-    "kafkaTopic": "sensor_others"
-  },
-  {
     "mqttTopic": "sensors/+/data",
     "kafkaTopic": "sensor_data"
+  },
+  {
+    "mqttTopic": "sensors/#",
+    "kafkaTopic": "sensor_others"
   }
 ]
 ```
@@ -59,7 +59,7 @@ Let's go through each rule to understand how the MQTT Bridge uses these rules to
     This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`. 
     For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
 
-The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
+The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because `"sensors/+/data"` matches the MQTT topic before `"sensors/#"`. If exchange the positions of the rules, the MQTT Bridge would use the `"sensors/#"` to map the MQTT topic to the Kafka topic "sensor_others".
 
 ### 2. MQTT Bridge Configuration
 
@@ -70,7 +70,7 @@ Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.
-- `kafka.` is the prefix used for Kafka producer configurations of the Bridge.
+- `kafka.` is the prefix used for Kafka configurations of the Bridge.
 
 A valid configuration file should look like this:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The following table describes the configuration properties that can be used to c
 | ------------------------------ | ----------------------------------------------- |-------------------|
 | bridge.id                      | ID of the bridge                                | my-bridge         |
 | mqtt.server.host               | Host address of the MQTT server                 | localhost         |
-| mqtt.server.port               | Port number of the MQTT server                  | 1883(default)     |
+| mqtt.server.port               | Port number of the MQTT server                  | 1883              |
 | kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092    |
 
 Other than the above properties, the user can also configure the bridge using environment variables.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It worth's mentioning that it is the user's responsibility to adhere to the [MQT
 The parts with curly braces in the MQTT topic pattern are called `placeholders`.
 The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.
 
-Let's go through each rule to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
+Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
 1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Let's go through each rule in the above example to understand how the MQTT Bridg
    For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
 
 
-The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because `"sensors/+/data"` matches the MQTT topic before `"sensors/#"`. If exchange the positions of the rules, the MQTT Bridge would use the `"sensors/#"` to map the MQTT topic to the Kafka topic "sensor_others".
+The order in which the rules are defined is important.
+The MQTT Bridge will use the first rule that matches the MQTT topic.
+For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data` because `sensors/+/data` matches the MQTT topic before `sensors/#`. 
+If we swap the positions of the rules, the MQTT Bridge would use the `sensors/#` to map the MQTT topic to the Kafka topic `sensor_others`.
 
 ### MQTT Bridge Configuration
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has a default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in which Kafka topic to produce this message.
+This Kafka topic is defined by a template, `kafka Topic template`.
+However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka topic where the incoming message will be mapped to, known as `messages_default`.
 
 A valid TOMAR is a JSON file that contains an array of mapping rules. Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ A valid TOMAR is a JSON file that contains an array of mapping rules. Each mappi
 ]
 ```
 
-The wildcard "#" represents one or more levels in the MQTT topic hierarchy. The wildcard "+" represents a single level in the MQTT topic hierarchy.
+The wildcard "#" represents one or more levels in the MQTT topic hierarchy.
+The wildcard "+" represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
 The parts with curly braces in the MQTT topic pattern are called `placeholders`. The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.
-- `kafka.` is the prefix used for Kafka configuration of the Bridge.
+- `kafka.` is the prefix used for Kafka producer configurations of the Bridge.
 
 A valid configuration file should look like this:
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The following is an example of a valid TOMAR:
 ]
 ```
 
-The wildcard "#" represents one or more levels in the MQTT topic hierarchy.
-The wildcard "+" represents a single level in the MQTT topic hierarchy.
+The wildcard `#` represents one or more levels in the MQTT topic hierarchy.
+The wildcard `+` represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
 The parts with curly braces in the MQTT topic pattern are called `placeholders`.
@@ -53,20 +53,20 @@ The MQTT Bridge will extract the values of these placeholders from the MQTT topi
 
 Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
-1. MQTT Topic: `"building/{building}/room/{room}/#"` -> Kafka Topic: `"building_{building}room{room}"`
+1. MQTT Topic: `building/{building}/room/{room}/#` -> Kafka Topic: `building_{building}_room_{room}`
 
-    This rule maps MQTT topics of the form `"building/{building}/room/{room}/#"` to the Kafka topic `"building_{building}room{room}"`. 
-    For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+    This rule maps MQTT topics of the form `building/{building}/room/{room}/#` to the Kafka topic `building_{building}_room_{room}`. 
+    For example, if the MQTT topic is `building/A/room/1/floor/2` it will be mapped to the Kafka topic `building_A_room_1_floor_2`.
 
-2. MQTT Topic: `"sensors/+/data"` -> Kafka Topic: `"sensor_data"`
+2. MQTT Topic: `sensors/+/data` -> Kafka Topic: `sensor_data`
 
     This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`. 
     For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
 
-3. MQTT Topic: `"sensors/#"` -> Kafka Topic: `"sensor_others"`
+3. MQTT Topic: `sensors/#` -> Kafka Topic: `sensor_others`
 
-   This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others".
-   For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
+   This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka topic `sensor_others`.
+   For example, if the MQTT topic is `sensors/temperature/living-room`,  it will be mapped to the Kafka topic `sensor_others`.
 
 
 The order in which the rules are defined is important.

--- a/README.md
+++ b/README.md
@@ -53,22 +53,25 @@ The MQTT Bridge will extract the values of these placeholders from the MQTT topi
 
 Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
-1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
+1. MQTT Topic: `"building/{building}/room/{room}/#"` -> Kafka Topic: `"building_{building}room{room}"`
 
-    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+    This rule maps MQTT topics of the form `"building/{building}/room/{room}/#"` to the Kafka topic `"building_{building}room{room}"`. 
+    For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
 
-2. MQTT Topic: "sensors/#" -> Kafka Topic: "sensor_others"
-
-    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
-
-3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
+2. MQTT Topic: `"sensors/+/data"` -> Kafka Topic: `"sensor_data"`
 
     This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`. 
     For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
 
+3. MQTT Topic: `"sensors/#"` -> Kafka Topic: `"sensor_others"`
+
+   This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others".
+   For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
+
+
 The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because `"sensors/+/data"` matches the MQTT topic before `"sensors/#"`. If exchange the positions of the rules, the MQTT Bridge would use the `"sensors/#"` to map the MQTT topic to the Kafka topic "sensor_others".
 
-### 2. MQTT Bridge Configuration
+### MQTT Bridge Configuration
 
 The user can configure the MQTT Bridge using an `application.properties` file.
 This section describes the configuration properties that can be used to configure the MQTT Bridge. 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,116 @@
 # MQTT bridge for Apache Kafka®
 
 This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
+
+## Running the bridge
+
+### Locally
+
+Clone the repository and update your dependencies using maven.
+Afterward, edit the `config/application.properties` file which contains the configuration. And provide a valid [topic mapping rules file]().
+
+Once your configuration is ready, start the bridge using:
+
+```bash
+<application> --config-file config/application.properties --mapping-rules=path/to/mapping-rules
+```
+
+You can find more information about the topic mapping rules in the MQTT Bridge.
+
+### Running Tests
+```bash
+mvn clean test
+```
+
+## MQTT bridge documentation
+
+### 1. MQTT Bridge Overview
+You can use the MQTT bridge to take advantage of the benefits of both MQTT and Kafka in data processing and IoT system scenarios.
+
+#### 1.1 General overview.
+
+#### 1.2 How it works
+
+The MQTT Bridge is a netty-based MQTT server that is responsible for handling all the MQTT client connections and connections management and is responsible for all MQTT-based operations like QoS, error handling, and other capabilities Netty offers.
+
+The MQTT Bridge provides two interfaces to integrate MQTT and Apache Kafka. The mapper maps incoming MQTT topics to Kafka topics. Once this mapping is completed, the MQTT Bridge will transform the incoming MQTT payload to a valid Kafka record and then send to the appropriate Kafka topic through the bridge kafka Producer.
+
+#### 1.2.1 The MqttKafkaMapper
+This interface is responsible for mapping incoming MQTT topic to Kafka topic. How this mapping is should be made must be defined in the `Topic Mapping Rules(TOMAR)`.
+
+#### 1.2.2 Topic Mapping Rules(TOMAR)
+
+The TOMAR is a set of patterns the user provides, to which the MQTT Bridge will decide which Kafka topic to produce a message. 
+A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to.
+
+##### 1.2.2.1 Usage/Examples
+A valid TOMAR is a JSON file that contains an array of mapping rules. 
+Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
+```json
+[
+  {
+    "mqttTopic": "building/{building}/room/{room}/#",
+    "kafkaTopic": "building_{building}_room_{room}"
+  },
+  {
+    "mqttTopic": "sensors/#",
+    "kafkaTopic": "sensor_others"
+  },
+  {
+    "mqttTopic": "sensors/+/data",
+    "kafkaTopic": "sensor_data"
+  }
+]
+```
+Let's go through each rule:
+
+1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
+    This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". The wildcard "#" represents one or more levels in the topic hierarchy. For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+
+2. MQTT Topic: "sensors/#" -> Kafka Topic: "sensor_others"
+
+    This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". The "#" wildcard matches any number of levels. For example, if the MQTT topic is "sensors/temperature/living-room", it will be mapped to the Kafka topic "sensor_others".
+
+3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
+
+    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". The "+" wildcard matches a single level in the topic hierarchy. For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
+
+These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns. The MQTT Bridge uses these rules to map MQTT topics to Kafka topics.
+The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. For example, if the MQTT topic is "sensors/temperature/data", 
+it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
+
+### 2. MQTT Bridge Configuration
+The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
+The MQTT bridge can be configured using the appropriate prefix. Example:
+- `bridge.` is the prefix used for general configuration of the Bridge.
+- `mqtt.` is the prefix used for MQTT configuration of the Bridge.
+- `kafka.` is the prefix used for Kafka configuration of the Bridge.
+### 2.1 Procedure to configure the MQTT Bridge
+1. Find the `application.properties` file in the `config` directory.
+2. Edit the file to configure the MQTT Bridge.
+    A valid configuration file should look like this:
+    ```properties
+    # Bridge configuration
+    bridge.id=my-bridge
+    # MQTT configuration
+    mqtt.server.host=localhost
+    mqtt.server.port=1883
+    # Kafka configuration
+    kafka.bootstrap.servers=localhost:9092
+    ```
+3. Save the file.
+
+The following table describes the configuration properties that can be used to configure the MQTT Bridge.
+
+| Setting                        | Description                                     | E.g. Value              |
+| ------------------------------ | ----------------------------------------------- |-------------------------|
+| bridge.id                      | ID of the bridge                                | my-bridge               |
+| mqtt.server.host               | Host address of the MQTT server                 | localhost(default)      |
+| mqtt.server.port               | Port number of the MQTT server                  | 1883(default)           |
+| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092(default) |
+
+Other than the above properties, the user can also configure the bridge using environment variables.
+
+## License
+
+Strimzi Kafka Bridge is licensed under the [Apache License](./LICENSE), Version 2.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a software component which acts as a bridge between [MQTT 
 
 ## MQTT Bridge Overview
 
-#### 1.1 How it works
+### How it works
 
 To enable a seamless integration between MQTT and Kafka, the MQTT Bridge provides a way to map MQTT topics to Kafka topics. 
 This mapping is done using a set of predefined patterns and kafka topic templates. The MQTT Bridge uses these patterns to map MQTT topics to Kafka topics. 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ If the third rule was not defined, the MQTT Bridge would use the second rule to 
 
 ### 2. MQTT Bridge Configuration
 
-The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
+The user can configure the MQTT Bridge using the `application.properties` file.
+This section describes the configuration properties that can be used to configure the MQTT Bridge.
 The MQTT bridge can be configured using the appropriate prefix. Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.

--- a/README.md
+++ b/README.md
@@ -3,23 +3,7 @@
 
 # MQTT bridge for Apache Kafka®
 
-This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) 
-and an [Apache Kafka®](https://kafka.apache.org/) cluster.
-
-## Running the bridge
-
-### Locally
-
-Clone the repository and update your dependencies using maven.
-Afterward, edit the `config/application.properties` file which contains the configuration. And provide a valid [topic mapping rules file]().
-
-Once your configuration is ready, start the bridge using:
-
-```bash
-<application> --config-file config/application.properties --mapping-rules=path/to/mapping-rules
-```
-
-You can find more information about the topic mapping rules in the MQTT Bridge.
+This project provides a software component which acts as a bridge between [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and an [Apache Kafka®](https://kafka.apache.org/) cluster.
 
 ### Running Tests
 
@@ -43,10 +27,8 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 The TOMAR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which 
-Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. 
-However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka 
-topic where the incoming message will be mapped to, know as `messages_default`.
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the `TOMAR` so that the bridge knows in which Kafka topic to produce this message. This Kafka topic is defined by a template, `kafka Topic template`. 
+However, if the incoming MQTT message's topic does not match any pattern in the `TOMAR`, the Bridge has default Kafka topic where the incoming message will be mapped to, know as `messages_default`.
 
 A valid TOMAR is a JSON file that contains an array of mapping rules. 
 Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`. The following is an example of a valid TOMAR:
@@ -67,38 +49,34 @@ Each mapping rule is a JSON object that contains two properties: `mqttTopic` and
   }
 ]
 ```
+The wildcard "#" represents one or more levels in the topic hierarchy. The wildcard "+" represents a single level in the topic hierarchy.
 
 Let's go through each rule:
 
 1. MQTT Topic: "building/{building}/room/{room}/#" -> Kafka Topic: "building_{building}room{room}"
 
     This rule maps MQTT topics of the form "building/{building}/room/{room}/#" to the Kafka topic "building_{building}room{room}". 
-    The wildcard "#" represents one or more levels in the topic hierarchy. For example, if the MQTT topic is "building/A/room/1/floor/2", 
-    it will be mapped to the Kafka topic "building_A_room_1_floor_2".
+    For example, if the MQTT topic is "building/A/room/1/floor/2", it will be mapped to the Kafka topic "building_A_room_1_floor_2".
 
 2. MQTT Topic: "sensors/#" -> Kafka Topic: "sensor_others"
 
     This rule maps any MQTT topic starting with "sensors/" followed by any number of levels in the hierarchy to the Kafka topic "sensor_others". 
-    The "#" wildcard matches any number of levels. For example, if the MQTT topic is "sensors/temperature/living-room", 
-    it will be mapped to the Kafka topic "sensor_others".
+    For example, if the MQTT topic is "sensors/temperature/living-room",  it will be mapped to the Kafka topic "sensor_others".
 
 3. MQTT Topic: "sensors/+/data" -> Kafka Topic: "sensor_data"
 
-    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". The "+" 
-    wildcard matches a single level in the topic hierarchy. For example, if the MQTT topic is "sensors/temperature/data", 
-    it will be mapped to the Kafka topic "sensor_data".
+    This rule maps MQTT topics of the form "sensors/+/data" to the Kafka topic "sensor_data". 
+    For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data".
 
 These mapping rules demonstrate how different MQTT topics can be mapped to corresponding Kafka topics based on predefined patterns.
-The MQTT Bridge uses these rules to map MQTT topics to Kafka topics.
-The order in which the rules are defined is important. The MQTT Bridge will use the first rule that matches the MQTT topic. 
-For example, if the MQTT topic is "sensors/temperature/data", 
-it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. If the third rule was not defined,
-the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
+The MQTT Bridge uses these rules to map MQTT topics to Kafka topics. The order in which the rules are defined is important. 
+The MQTT Bridge will use the first rule that matches the MQTT topic. 
+For example, if the MQTT topic is "sensors/temperature/data", it will be mapped to the Kafka topic "sensor_data" because the third rule matches the MQTT topic. 
+If the third rule was not defined, the MQTT Bridge would use the second rule to map the MQTT topic to the Kafka topic "sensor_others".
 
 ### 2. MQTT Bridge Configuration
 
-The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration 
-properties that can be used to configure the MQTT Bridge.
+The user can configure the MQTT Bridge using the `application.properties` file. This section describes the configuration properties that can be used to configure the MQTT Bridge.
 The MQTT bridge can be configured using the appropriate prefix. Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
@@ -123,12 +101,12 @@ The MQTT bridge can be configured using the appropriate prefix. Example:
 
 The following table describes the configuration properties that can be used to configure the MQTT Bridge.
 
-| Setting                        | Description                                     | Default           |
-| ------------------------------ | ----------------------------------------------- |-------------------|
-| bridge.id                      | ID of the bridge                                | my-bridge         |
-| mqtt.server.host               | Host address of the MQTT server                 | localhost         |
-| mqtt.server.port               | Port number of the MQTT server                  | 1883              |
-| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092    |
+| Setting                        | Description                                     | Default        |
+| ------------------------------ | ----------------------------------------------- |----------------|
+| bridge.id                      | ID of the bridge                                | my-bridge      |
+| mqtt.server.host               | Host address of the MQTT server                 | localhost      |
+| mqtt.server.port               | Port number of the MQTT server                  | 1883           |
+| kafka.bootstrap.servers        | Bootstrap servers for Apache Kafka              | localhost:9092 |
 
 Other than the above properties, the user can also configure the bridge using environment variables.
 


### PR DESCRIPTION
This PR proposes the documentation for the MQTT bridge. It contains the following informations:
> How to run the Bridge
> How to use the Bridge
> How to configure the bridge.

Signed-off-by: Antonio Pedro <tonio.pedro99@gmail.com> 