### PR TITLE
Fix logging layout

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = MqttBridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console


### PR DESCRIPTION
Current log layout pattern is very bad by cutting classes and thread names. This PR uses the same layout from the Strimzi cluster operator.