### PR TITLE
feat: added a new MqttKafkaMapper and updated docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The expression `([^/]+)` is used to represent the wildcard `+`, which in turn re
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
 Placeholders in the `KafkaTopic` and `kafkaKey` templates are defined using the `$` character followed by a number. 
-The number represents the index of the capturing group in the `mqttTopic` pattern.
-The MQTT Bridge uses the capturing groups in the `mqttTopic` pattern to positionally extract the values that will be used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
+The number represents the index of the `capturing group` in the `mqttTopic` pattern. `Please note that the index starts from 1 and not 0`.
+The MQTT Bridge uses the `capturing groups` in the `mqttTopic` pattern to positionally extract the values that will be used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
 
 Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 

--- a/README.md
+++ b/README.md
@@ -36,23 +36,22 @@ The following is an example of a valid ToMaR:
 ```json
 [
   {
-    "mqttTopic": "building/(\\w+)/room/(\\d{1,4}).*",
-    "kafkaTopic": "building_$1_room_$2",
-    "kafkaKey": "room_$2"
+     "mqttTopic": "building/(\\w+)/room/(\\d{1,4}).*",
+     "kafkaTopic": "building_$1",
+     "kafkaKey": "room_$2"
   },
   {
     "mqttTopic": "sensors/([^/]+)/data",
     "kafkaTopic": "sensor_data"
   },
   {
-    "mqttTopic": "sensors.*",
-    "kafkaTopic": "sensor_others",
-    "kafkaKey": "sensor"
+     "mqttTopic": "sensors.*",
+     "kafkaTopic": "sensor_others"
   },
   {
     "mqttTopic": "devices/([^/]+)/data/(\b(all|new|old)\b)",
-    "kafkaTopic": "device_$1_data",
-    "kafkaKey": "device_$1"
+     "kafkaTopic": "device_$1_data",
+     "kafkaKey": "device_$2"
   }
 ]
 ```
@@ -73,32 +72,33 @@ used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
 Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to
 Kafka topics:
 
-1. MQTT Topic: `building/(\\w+)/room/(\\d{1,4}).*` -> Kafka Topic: `building_$1_room_$2`
+1. MQTT Topic: `building/(\\w+)/room/(\\d{1,4}).*` -> Kafka Topic: `building_$1` with Kafka Key: `room_$2`
 
    This rule maps MQTT topics of the form `building/{some word}/room/{some number with 4 digits}/#` to the Kafka
-   topic `building_$1_room_$2`.
+   topic `building_$1`.
    For example, if the MQTT topic is `building/A/room/1003/floor/2` it will be mapped to the Kafka
-   topic `building_A_room_1003` with the key `room_1003`.
+   topic `building_A` with the key `room_1003`.
 
-2. MQTT Topic: `sensors/([^/]+)/data` -> Kafka Topic: `sensor_data`
+2. MQTT Topic: `sensors/([^/]+)/data` -> Kafka Topic: `sensor_data` with Kafka Key: `null`
 
    This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`.
    For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
    Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
 
-3. MQTT Topic: `sensors.*` -> Kafka Topic: `sensor_others`
+3. MQTT Topic: `sensors.*` -> Kafka Topic: `sensor_others` with Kafka Key: `null`
 
    This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka
    topic `sensor_others`.
    For example, if the MQTT topic is `sensors/temperature/living-room`, it will be mapped to the Kafka
    topic `sensor_others` with the key `sensor`.
+   Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
 
-4. MQTT Topic: `devices/([^/]+)/data/(\b(all|new|old)\b)` -> Kafka Topic: `device_$1_data`
+4. MQTT Topic: `devices/([^/]+)/data/(\b(all|new|old)\b)` -> Kafka Topic: `device_$1_data` with Kafka Key: `device_$2`
 
    This rule maps MQTT topics of the form `devices/{some word}/data/{either all, new or old}` to the Kafka
    topic `device_$1_data`.
    For example, if the MQTT topic is `devices/thermostat/data/all`, it will be mapped to the Kafka
-   topic `device_thermostat_data` with the key `device_thermostat`.
+   topic `device_thermostat_data` with the key `device_all`.
    This example also shows the advantage of using regex in the `mqttTopic` pattern. The last capturing group in
    the `mqttTopic` should be a word boundary `\b` followed by either `all`, `new` or `old` and anything else will not
    match the pattern.

--- a/README.md
+++ b/README.md
@@ -17,62 +17,98 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 ### Topic Mapping Rules (ToMaR)
 
-The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
-A Mapping Rule is a model that contains an `MQTT topic pattern` and a `Kafka topic template`. 
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in which Kafka topic to produce this message.
+The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic
+names.
+A Mapping Rule is a model that contains an `MQTT topic pattern`, a `Kafka topic template`, and optionally
+a `Kafka record key`.
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in
+which Kafka topic to produce this message.
 This Kafka topic is defined by a template, `Kafka Topic template`.
-However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka topic where the incoming message will be mapped to, known as `messages_default`.
+However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka
+topic where the incoming message will be mapped to, known as `messages_default`.
 
-A valid ToMaR is a JSON file that contains an array of mapping rules. 
+The optional `Kafka record key` is used to define the key of the Kafka record that will be produced to the Kafka topic.
+It is defined by a template as well, and its default value is `null`.
+A valid ToMaR is a JSON file that contains an array of mapping rules.
 Each mapping rule is a JSON object that contains two properties: `mqttTopic` and `kafkaTopic`.
-The following is an example of a valid TOMAR:
+The following is an example of a valid ToMaR:
 
 ```json
 [
   {
-    "mqttTopic": "building/{building}/room/{room}/#",
-    "kafkaTopic": "building_{building}_room_{room}"
+    "mqttTopic": "building/(\\w+)/room/(\\d{1,4}).*",
+    "kafkaTopic": "building_$1_room_$2",
+    "kafkaKey": "room_$2"
   },
   {
-    "mqttTopic": "sensors/+/data",
+    "mqttTopic": "sensors/([^/]+)/data",
     "kafkaTopic": "sensor_data"
   },
   {
-    "mqttTopic": "sensors/#",
-    "kafkaTopic": "sensor_others"
+    "mqttTopic": "sensors.*",
+    "kafkaTopic": "sensor_others",
+    "kafkaKey": "sensor"
+  },
+  {
+    "mqttTopic": "devices/([^/]+)/data/(\b(all|new|old)\b)",
+    "kafkaTopic": "device_$1_data",
+    "kafkaKey": "device_$1"
   }
 ]
 ```
 
-The wildcard `#` represents one or more levels in the MQTT topic hierarchy.
-The wildcard `+` represents a single level in the MQTT topic hierarchy.
-It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
+The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic
+hierarchy.
+The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT
+topic hierarchy.
+It worth's mentioning that it is the user's responsibility to adhere to
+the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106)
+when defining the MQTT topic patterns.
 
-The parts with curly braces in the MQTT topic pattern are called `placeholders`.
-The MQTT Bridge will extract the values of these placeholders from the MQTT topic and use them to construct the Kafka topic name using the `kafkaTopic` template.
+Placeholders in the `KafkaTopic` and `kafkaKey` template are defined using the `$` character followed by a number. The
+number represents the index of the capturing group in the `mqttTopic` pattern.
+The MQTT Bridge uses the capturing groups in the `mqttTopic` pattern to positionally extract the values that will be
+used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
 
-Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
+Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to
+Kafka topics:
 
-1. MQTT Topic: `building/{building}/room/{room}/#` -> Kafka Topic: `building_{building}_room_{room}`
+1. MQTT Topic: `building/(\\w+)/room/(\\d{1,4}).*` -> Kafka Topic: `building_$1_room_$2`
 
-    This rule maps MQTT topics of the form `building/{building}/room/{room}/#` to the Kafka topic `building_{building}_room_{room}`. 
-    For example, if the MQTT topic is `building/A/room/1/floor/2` it will be mapped to the Kafka topic `building_A_room_1_floor_2`.
+   This rule maps MQTT topics of the form `building/{some word}/room/{some number with 4 digits}/#` to the Kafka
+   topic `building_$1_room_$2`.
+   For example, if the MQTT topic is `building/A/room/1003/floor/2` it will be mapped to the Kafka
+   topic `building_A_room_1003` with the key `room_1003`.
 
-2. MQTT Topic: `sensors/+/data` -> Kafka Topic: `sensor_data`
+2. MQTT Topic: `sensors/([^/]+)/data` -> Kafka Topic: `sensor_data`
 
-    This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`. 
-    For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
+   This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`.
+   For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
+   Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
 
-3. MQTT Topic: `sensors/#` -> Kafka Topic: `sensor_others`
+3. MQTT Topic: `sensors.*` -> Kafka Topic: `sensor_others`
 
-   This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka topic `sensor_others`.
-   For example, if the MQTT topic is `sensors/temperature/living-room`,  it will be mapped to the Kafka topic `sensor_others`.
+   This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka
+   topic `sensor_others`.
+   For example, if the MQTT topic is `sensors/temperature/living-room`, it will be mapped to the Kafka
+   topic `sensor_others` with the key `sensor`.
 
+4. MQTT Topic: `devices/([^/]+)/data/(\b(all|new|old)\b)` -> Kafka Topic: `device_$1_data`
+
+   This rule maps MQTT topics of the form `devices/{some word}/data/{either all, new or old}` to the Kafka
+   topic `device_$1_data`.
+   For example, if the MQTT topic is `devices/thermostat/data/all`, it will be mapped to the Kafka
+   topic `device_thermostat_data` with the key `device_thermostat`.
+   This example also shows the advantage of using regex in the `mqttTopic` pattern. The last capturing group in
+   the `mqttTopic` should be a word boundary `\b` followed by either `all`, `new` or `old` and anything else will not
+   match the pattern.
 
 The order in which the rules are defined is important.
 The MQTT Bridge will use the first rule that matches the MQTT topic.
-For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data` because `sensors/+/data` matches the MQTT topic before `sensors/#`. 
-If we swap the positions of the rules, the MQTT Bridge would use the `sensors/#` to map the MQTT topic to the Kafka topic `sensor_others`.
+For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`
+because `sensors/([^/]+)/data` matches the MQTT topic before `sensors/#`.
+If we swap the positions of the rules, the MQTT Bridge would use the `sensors.*` to map the MQTT topic to the Kafka
+topic `sensor_others`.
 
 ### MQTT Bridge Configuration
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Therefore, you should note the following:
   On the other hand, the pattern `building/.*` will match `building/room`, `building/floor/room`, and so on, but not `buildingroom` and `building/`. 
   - You can also use the `(?:\\/.*)?$` wildcard to match the whole subtopic level of the pattern. 
   For example, the pattern `locations/([^/]+)(?:\\/.*)?$` will match `locations/city/luanda/angola`, `locations/city`, `locations/city/`, and so on. 
-  It's literally equivalent to `locations/+/#`.
+  It's literally equivalent to `locations/+/#`.  
+  Please note that the `(?:\\/.*)?$` wildcard is a non-capturing group, which means that it will not be used to replace the placeholders in the `kafkaTopic` and `kafkaKey` templates.
+  - The `(?:\\/.*)?$` wildcard is different from the `.*` wildcard. For example, the pattern `sensors.*` will match everything after `sensors`, seperated with a slash or not. For example, `sensors`, `sensors/`, `sensorsdata`, and so on. 
+  On the other hand, the pattern `sensors(?:\\/.*)?$` will match `sensors`, `sensors/`, `sensors/data`, and so on, but not `sensorsdata`.
 - The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The following is an example of a valid ToMaR:
 The expressions `.*` and `(?:\\/.*)?$` are used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
 However, there are some cases that can lead to unexpected behavior when using the these wildcards interchangeably . 
 Therefore, you should note the following:
-  - You can not use the `.*` wildcard in capturing groups. 
+  - You cannot use the `.*` wildcard in capturing groups. 
   For example, the pattern `building/(\\w+)/room/(\\d{1,4})/(.*)` is invalid because it will capture the whole subtopic of the pattern, and `$3` placeholder might include `/` characters, which will lead to an invalid Kafka topic name.
   - You can use the `.*` wildcard without a preceding `/` character, but it is not equivalent to when it is preceded by `/`. 
   For example, the pattern `building.*` will match `building`, `building/room`, `buildingroom`, and so on. 
   On the other hand, the pattern `building/.*` will match `building/room`, `building/floor/room`, and so on, but not `buildingroom` and `building/`. 
   - You can also use the `(?:\\/.*)?$` wildcard to match the whole subtopic level of the pattern. 
-  For example, the pattern `locations/([^/]+)(?:\\/.*)?$` will match `locations/city/luanda/angola`, `locations/country`, and so on. 
+  For example, the pattern `locations/([^/]+)(?:\\/.*)?$` will match `locations/city/luanda/angola`, `locations/city`, `locations/city/`, and so on. 
   It's literally equivalent to `locations/+/#`.
 - The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Let's go through each rule in the above example to understand how the MQTT Bridg
 
    This rule maps MQTT topics of the form `sensors/+/data` to the Kafka topic `sensor_data`.
    For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`.
-   Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
+   Because the `kafkaKey` is not defined, the key of the Kafka record will be `null`.
 
 3. MQTT Topic: `sensors.*` -> Kafka Topic: `sensor_others` with Kafka Key: `null`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 
 ### Topic Mapping Rules (ToMaR)
 
-The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic
+The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
 names.
 A Mapping Rule is a model that contains an `MQTT topic pattern`, a `Kafka topic template`, and optionally
 a `Kafka record key`.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,26 @@ The following is an example of a valid ToMaR:
     "mqttTopic": "devices/([^/]+)/data/(\b(all|new|old)\b)",
      "kafkaTopic": "device_$1_data",
      "kafkaKey": "device_$2"
+  },
+  {
+      "mqttTopic": "locations/([^/]+)(?:\\/.*)?$",
+      "kafkaTopic": "locations",
+      "kafkaKey": "location_$1"
   }
 ]
 ```
 
-- The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
-However, there are some cases that can lead to unexpected behavior when using the `.*` wildcard.
+The expressions `.*` and `(?:\\/.*)?$` are used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
+However, there are some cases that can lead to unexpected behavior when using the these wildcards interchangeably . 
 Therefore, you should note the following:
-  - You cannot use the `.*` wildcard in capturing groups. 
+  - You can not use the `.*` wildcard in capturing groups. 
   For example, the pattern `building/(\\w+)/room/(\\d{1,4})/(.*)` is invalid because it will capture the whole subtopic of the pattern, and `$3` placeholder might include `/` characters, which will lead to an invalid Kafka topic name.
   - You can use the `.*` wildcard without a preceding `/` character, but it is not equivalent to when it is preceded by `/`. 
   For example, the pattern `building.*` will match `building`, `building/room`, `buildingroom`, and so on. 
-  On the other hand, the pattern `building/.*` will match `building`, `building/room`, `building/floor/room`, and so on, but not `buildingroom`. 
+  On the other hand, the pattern `building/.*` will match `building/room`, `building/floor/room`, and so on, but not `buildingroom` and `building/`. 
+  - You can also use the `(?:\\/.*)?$` wildcard to match the whole subtopic level of the pattern. 
+  For example, the pattern `locations/([^/]+)(?:\\/.*)?$` will match `locations/city/luanda/angola`, `locations/country`, and so on. 
+  It's literally equivalent to `locations/+/#`.
 - The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The expression `.*` is used to represent the wildcard `#`, which in turn represe
 The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
-Placeholders in the `KafkaTopic` and `kafkaKey` templates are defined using the `$` character followed by a number. 
+Placeholders in the `kafkaTopic` and `kafkaKey` templates are defined using the `$` character followed by a number. 
 The number represents the index of the `capturing group` in the `mqttTopic` pattern. `Please note that the index starts from 1 and not 0`.
-The MQTT Bridge uses the `capturing groups` in the `mqttTopic` pattern to positionally extract the values that will be used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
+The MQTT Bridge uses the `capturing groups` in the `mqttTopic` pattern to positionally extract the values that will be used to replace the placeholders in the `kafkaTopic` and `kafkaKey` templates.
 
 Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following is an example of a valid ToMaR:
 ```json
 [
   {
-     "mqttTopic": "building/(\\w+)/room/(\\d{1,4}).*",
+     "mqttTopic": "building/(\\w+)/room/(\\d{1,4})/.*",
      "kafkaTopic": "building_$1",
      "kafkaKey": "room_$2"
   },
@@ -52,8 +52,11 @@ The following is an example of a valid ToMaR:
 ]
 ```
 
-The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
-The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
+- The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
+However, there are some cases that can lead to unexpected behavior when using the `.*` wildcard. Therefore, you should note the following:
+  - You can not use the `.*` wildcard in capturing groups. For example, the pattern `building/(\\w+)/room/(\\d{1,4})/(.*)` is invalid because it will capture the whole subtopic of the pattern, and `$3` placeholder might include `/` characters, which will lead to an invalid Kafka topic name.
+  - You can use the `.*` wildcard without a preceding `/` character, but it is not equivalent to when it is preceded by `/`. For example, the pattern `building.*` will match `building`, `building/room`, `buildingroom`, and so on. On the other hand, the pattern `building/.*` will match `building`, `building/room`, `building/floor/room`, and so on, but not `buildingroom`. 
+- The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
 Placeholders in the `kafkaTopic` and `kafkaKey` templates are defined using the `$` character followed by a number. 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ As a part of the bridge, a Kafka producer will be responsible for producing mess
 ### Topic Mapping Rules (ToMaR)
 
 The ToMaR is a set of patterns the user provides defining how the MQTT Bridge maps MQTT topic names to Kafka topic names.
-names.
-A Mapping Rule is a model that contains an `MQTT topic pattern`, a `Kafka topic template`, and optionally
-a `Kafka record key`.
-All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in
-which Kafka topic to produce this message.
+A Mapping Rule is a model that contains an `MQTT topic pattern`, a `Kafka topic template`, and optionally a `Kafka record key`.
+All the incoming MQTT message's topic should match an `MQTT topic pattern` in the ToMaR so that the bridge knows in which Kafka topic to produce this message.
 This Kafka topic is defined by a template, `Kafka Topic template`.
-However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka
-topic where the incoming message will be mapped to, known as `messages_default`.
+However, if the incoming MQTT message's topic does not match any pattern in the ToMaR, the Bridge has a default Kafka topic where the incoming message will be mapped to, known as `messages_default`.
 
 The optional `Kafka record key` is used to define the key of the Kafka record that will be produced to the Kafka topic.
 It is defined by a template as well, and its default value is `null`.
@@ -56,28 +52,20 @@ The following is an example of a valid ToMaR:
 ]
 ```
 
-The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic
-hierarchy.
-The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT
-topic hierarchy.
-It worth's mentioning that it is the user's responsibility to adhere to
-the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106)
-when defining the MQTT topic patterns.
+The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
+The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
+It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 
-Placeholders in the `KafkaTopic` and `kafkaKey` template are defined using the `$` character followed by a number. The
-number represents the index of the capturing group in the `mqttTopic` pattern.
-The MQTT Bridge uses the capturing groups in the `mqttTopic` pattern to positionally extract the values that will be
-used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
+Placeholders in the `KafkaTopic` and `kafkaKey` templates are defined using the `$` character followed by a number. 
+The number represents the index of the capturing group in the `mqttTopic` pattern.
+The MQTT Bridge uses the capturing groups in the `mqttTopic` pattern to positionally extract the values that will be used to replace the placeholders in the `KafkaTopic` and `kafkaKey` templates.
 
-Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to
-Kafka topics:
+Let's go through each rule in the above example to understand how the MQTT Bridge uses these rules to map MQTT topics to Kafka topics:
 
 1. MQTT Topic: `building/(\\w+)/room/(\\d{1,4}).*` -> Kafka Topic: `building_$1` with Kafka Key: `room_$2`
 
-   This rule maps MQTT topics of the form `building/{some word}/room/{some number with 4 digits}/#` to the Kafka
-   topic `building_$1`.
-   For example, if the MQTT topic is `building/A/room/1003/floor/2` it will be mapped to the Kafka
-   topic `building_A` with the key `room_1003`.
+   This rule maps MQTT topics of the form `building/{some word}/room/{some number with 4 digits}/#` to the Kafka topic `building_$1`.
+   For example, if the MQTT topic is `building/A/room/1003/floor/2` it will be mapped to the Kafka topic `building_A` with the key `room_1003`.
 
 2. MQTT Topic: `sensors/([^/]+)/data` -> Kafka Topic: `sensor_data` with Kafka Key: `null`
 
@@ -87,35 +75,26 @@ Kafka topics:
 
 3. MQTT Topic: `sensors.*` -> Kafka Topic: `sensor_others` with Kafka Key: `null`
 
-   This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka
-   topic `sensor_others`.
-   For example, if the MQTT topic is `sensors/temperature/living-room`, it will be mapped to the Kafka
-   topic `sensor_others` with the key `sensor`.
+   This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka topic `sensor_others`.
+   For example, if the MQTT topic is `sensors/temperature/living-room`, it will be mapped to the Kafka topic `sensor_others` with the key `sensor`.
    Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
 
 4. MQTT Topic: `devices/([^/]+)/data/(\b(all|new|old)\b)` -> Kafka Topic: `device_$1_data` with Kafka Key: `device_$2`
 
-   This rule maps MQTT topics of the form `devices/{some word}/data/{either all, new or old}` to the Kafka
-   topic `device_$1_data`.
-   For example, if the MQTT topic is `devices/thermostat/data/all`, it will be mapped to the Kafka
-   topic `device_thermostat_data` with the key `device_all`.
-   This example also shows the advantage of using regex in the `mqttTopic` pattern. The last capturing group in
-   the `mqttTopic` should be a word boundary `\b` followed by either `all`, `new` or `old` and anything else will not
-   match the pattern.
+   This rule maps MQTT topics of the form `devices/{some word}/data/{either all, new or old}` to the Kafka topic `device_$1_data`.
+   For example, if the MQTT topic is `devices/thermostat/data/all`, it will be mapped to the Kafka topic `device_thermostat_data` with the key `device_all`.
+   This example also shows the advantage of using regex in the `mqttTopic` pattern. The last capturing group in the `mqttTopic` should be a word boundary `\b` followed by either `all`, `new` or `old` and anything else will not match the pattern.
 
 The order in which the rules are defined is important.
 The MQTT Bridge will use the first rule that matches the MQTT topic.
-For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data`
-because `sensors/([^/]+)/data` matches the MQTT topic before `sensors/#`.
-If we swap the positions of the rules, the MQTT Bridge would use the `sensors.*` to map the MQTT topic to the Kafka
-topic `sensor_others`.
+For example, if the MQTT topic is `sensors/temperature/data`, it will be mapped to the Kafka topic `sensor_data` because `sensors/([^/]+)/data` matches the MQTT topic before `sensors/#`.
+If we swap the positions of the rules, the MQTT Bridge would use the `sensors.*` to map the MQTT topic to the Kafka  topic `sensor_others`.
 
 ### MQTT Bridge Configuration
 
 The user can configure the MQTT Bridge using an `application.properties` file.
 This section describes the configuration properties that can be used to configure the MQTT Bridge. 
-The MQTT bridge can be configured using the appropriate prefix.
-Example:
+The MQTT bridge can be configured using the appropriate prefix. Example:
 
 - `bridge.` is the prefix used for general configuration of the Bridge.
 - `mqtt.` is the prefix used for MQTT configuration of the Bridge.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Let's go through each rule in the above example to understand how the MQTT Bridg
 
    This rule maps any MQTT topic starting with `sensors/` followed by any number of levels in the hierarchy to the Kafka topic `sensor_others`.
    For example, if the MQTT topic is `sensors/temperature/living-room`, it will be mapped to the Kafka topic `sensor_others` with the key `sensor`.
-   Because the `KafkaKey` is not defined, the key of the Kafka record will be `null`.
+   Because the `kafkaKey` is not defined, the key of the Kafka record will be `null`.
 
 4. MQTT Topic: `devices/([^/]+)/data/(\b(all|new|old)\b)` -> Kafka Topic: `device_$1_data` with Kafka Key: `device_$2`
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ The following is an example of a valid ToMaR:
 ```
 
 - The expression `.*` is used to represent the wildcard `#`, which in turn represents one or more levels in the MQTT topic hierarchy.
-However, there are some cases that can lead to unexpected behavior when using the `.*` wildcard. Therefore, you should note the following:
-  - You can not use the `.*` wildcard in capturing groups. For example, the pattern `building/(\\w+)/room/(\\d{1,4})/(.*)` is invalid because it will capture the whole subtopic of the pattern, and `$3` placeholder might include `/` characters, which will lead to an invalid Kafka topic name.
-  - You can use the `.*` wildcard without a preceding `/` character, but it is not equivalent to when it is preceded by `/`. For example, the pattern `building.*` will match `building`, `building/room`, `buildingroom`, and so on. On the other hand, the pattern `building/.*` will match `building`, `building/room`, `building/floor/room`, and so on, but not `buildingroom`. 
+However, there are some cases that can lead to unexpected behavior when using the `.*` wildcard.
+Therefore, you should note the following:
+  - You cannot use the `.*` wildcard in capturing groups. 
+  For example, the pattern `building/(\\w+)/room/(\\d{1,4})/(.*)` is invalid because it will capture the whole subtopic of the pattern, and `$3` placeholder might include `/` characters, which will lead to an invalid Kafka topic name.
+  - You can use the `.*` wildcard without a preceding `/` character, but it is not equivalent to when it is preceded by `/`. 
+  For example, the pattern `building.*` will match `building`, `building/room`, `buildingroom`, and so on. 
+  On the other hand, the pattern `building/.*` will match `building`, `building/room`, `building/floor/room`, and so on, but not `buildingroom`. 
 - The expression `([^/]+)` is used to represent the wildcard `+`, which in turn represents a single level in the MQTT topic hierarchy.
 It worth's mentioning that it is the user's responsibility to adhere to the [MQTT 3.1.1 naming conventions](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106) when defining the MQTT topic patterns.
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -14,6 +14,7 @@ import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.strimzi.kafka.bridge.mqtt.kafka.KafkaBridgeProducer;
+import io.strimzi.kafka.bridge.mqtt.mapper.MappingResult;
 import io.strimzi.kafka.bridge.mqtt.mapper.MappingRule;
 import io.strimzi.kafka.bridge.mqtt.mapper.MqttKafkaMapper;
 import io.strimzi.kafka.bridge.mqtt.utils.MappingRulesLoader;
@@ -138,14 +139,17 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
         String mqttTopic = publishMessage.variableHeader().topicName();
 
         // perform topic mapping
-        String kafkaMappedTopic = mqttKafkaMapper.map(mqttTopic);
+        MappingResult mqttKafkaMappingResult = mqttKafkaMapper.map(mqttTopic);
+
+        String kafkaMappedTopic = mqttKafkaMappingResult.getKafkaTopic();
+        String key = mqttKafkaMappingResult.getKafkaKey();
 
         //log the topic mapping
-        logger.info("MQTT topic {} mapped to Kafka Topic {}", mqttTopic, kafkaMappedTopic);
+        logger.info("MQTT topic {} mapped to Kafka Topic {} with Key {}", mqttTopic, kafkaMappedTopic, key);
 
         byte[] data = payloadToBytes(publishMessage);
         // build the Kafka record
-        ProducerRecord<String, byte[]> record = new ProducerRecord<>(kafkaMappedTopic,
+        ProducerRecord<String, byte[]> record = new ProducerRecord<>(kafkaMappedTopic, key,
                 data);
 
         // send the record to the Kafka topic

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -60,7 +60,7 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
     }
 
     /**
-     * Transform a MqttPublishMessage's payload into byte array
+     * Transform a MqttPublishMessage's payload into bytes array
      */
     private static byte[] payloadToBytes(MqttPublishMessage msg) {
         byte[] data = new byte[msg.payload().readableBytes()];
@@ -143,7 +143,7 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
         // perform topic mapping
         MappingResult mappingResult = mqttKafkaMapper.map(mqttTopic);
 
-        //log the topic mapping
+        // log the topic mapping
         logger.info("MQTT topic {} mapped to Kafka Topic {} with Key {}", mqttTopic, mappingResult.kafkaTopic(), mappingResult.kafkaKey());
 
         byte[] data = payloadToBytes(publishMessage);

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.mapper;
+
+/**
+ * Represents the result of a mapping operation.
+ * It contains the mapped kafka topic and the kafka key.
+ */
+public class MappingResult {
+    private String kafkaTopic;
+    private String kafkaKey;
+
+    /**
+     * Constructor for MappingResult.
+     *
+     * @param kafkaTopic the mapped kafka topic.
+     * @param kafkaKey   the kafka key.
+     */
+    public MappingResult(String kafkaTopic, String kafkaKey) {
+        this.kafkaTopic = kafkaTopic;
+        this.kafkaKey = kafkaKey;
+    }
+
+    /**
+     * Get the mapped kafka topic.
+     *
+     * @return the mapped kafka topic.
+     */
+    public String getKafkaTopic() {
+        return kafkaTopic;
+    }
+
+    /**
+     * Set the mapped kafka topic.
+     *
+     * @param mappedKafkaTopic the mapped kafka topic.
+     */
+    public void setKafkaTopic(String mappedKafkaTopic) {
+        this.kafkaTopic = mappedKafkaTopic;
+    }
+
+    /**
+     * Get the kafka key.
+     *
+     * @return the kafka key.
+     */
+    public String getKafkaKey() {
+        return kafkaKey;
+    }
+
+    /**
+     * Set the kafka key.
+     *
+     * @param kafkaKey the kafka key.
+     */
+    public void setKafkaKey(String kafkaKey) {
+        this.kafkaKey = kafkaKey;
+    }
+
+    @Override
+    public String toString() {
+        return "MappingResult(kafkaTopic= "
+                + this.kafkaTopic
+                + ", kafkaKey=" + this.kafkaKey + ")";
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
@@ -7,62 +7,17 @@ package io.strimzi.kafka.bridge.mqtt.mapper;
 /**
  * Represents the result of a mapping operation.
  * It contains the mapped kafka topic and the kafka key.
+ *
+ * @param kafkaTopic the mapped kafka topic.
+ * @param kafkaKey   the kafka key.
  */
-public class MappingResult {
-    private String kafkaTopic;
-    private String kafkaKey;
-
-    /**
-     * Constructor for MappingResult.
-     *
-     * @param kafkaTopic the mapped kafka topic.
-     * @param kafkaKey   the kafka key.
-     */
-    public MappingResult(String kafkaTopic, String kafkaKey) {
-        this.kafkaTopic = kafkaTopic;
-        this.kafkaKey = kafkaKey;
-    }
-
-    /**
-     * Get the mapped kafka topic.
-     *
-     * @return the mapped kafka topic.
-     */
-    public String getKafkaTopic() {
-        return kafkaTopic;
-    }
-
-    /**
-     * Set the mapped kafka topic.
-     *
-     * @param mappedKafkaTopic the mapped kafka topic.
-     */
-    public void setKafkaTopic(String mappedKafkaTopic) {
-        this.kafkaTopic = mappedKafkaTopic;
-    }
-
-    /**
-     * Get the kafka key.
-     *
-     * @return the kafka key.
-     */
-    public String getKafkaKey() {
-        return kafkaKey;
-    }
-
-    /**
-     * Set the kafka key.
-     *
-     * @param kafkaKey the kafka key.
-     */
-    public void setKafkaKey(String kafkaKey) {
-        this.kafkaKey = kafkaKey;
-    }
+public record MappingResult(String kafkaTopic, String kafkaKey) {
 
     @Override
     public String toString() {
-        return "MappingResult(kafkaTopic= "
-                + this.kafkaTopic
-                + ", kafkaKey=" + this.kafkaKey + ")";
+        return "MappingResult(" +
+                "kafkaTopic=" + kafkaTopic +
+                ", kafkaKey=" + kafkaKey +
+                ")";
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingResult.java
@@ -6,10 +6,10 @@ package io.strimzi.kafka.bridge.mqtt.mapper;
 
 /**
  * Represents the result of a mapping operation.
- * It contains the mapped kafka topic and the kafka key.
+ * It contains the mapped Kafka topic and the Kafka key.
  *
- * @param kafkaTopic the mapped kafka topic.
- * @param kafkaKey   the kafka key.
+ * @param kafkaTopic the mapped Kafka topic.
+ * @param kafkaKey   the Kafka key.
  */
 public record MappingResult(String kafkaTopic, String kafkaKey) {
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -64,7 +64,7 @@ public class MappingRule {
     }
 
     /**
-     * Get the record key.
+     * Get the record key template.
      *
      * @return the record key template.
      */

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *      "kafkaKey": "sensor_$2"
  * }
  * and like this in the MappingRule class:
- * MappingRule(mqttTopicPattern= sensors/(^[0-9])/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$2)
+ * MappingRule(mqttTopicPattern=sensors/(^[0-9])/type/([^/]+)/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$2)
  */
 public class MappingRule {
     @JsonProperty("mqttTopic")

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -10,12 +10,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents a Mapping Rule in the Topic Mapping Rules(ToMaR). Mapping rules are used to define how MQTT topics should be mapped to Kafka topics, and additionally define the record key.
  * E.g.: a valid mapping rule would look like this in the ToMaR file:
  * {
- * "mqttTopic": "sensors/(^[0-9])/data",
+ * "mqttTopic": "sensors/(^[0-9])/type/([^/]+)/data",
  * "kafkaTopic": "sensors_$1_data",
- * "kafkaKey": "sensor_$1"
+ * "kafkaKey": "sensor_$2"
  * }
  * and like this in the MappingRule class:
- * MappingRule(mqttTopicPattern= sensors/(^[0-9])/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$1)
+ * MappingRule(mqttTopicPattern= sensors/(^[0-9])/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$2)
  */
 public class MappingRule {
     @JsonProperty("mqttTopic")
@@ -24,7 +24,7 @@ public class MappingRule {
     private String kafkaTopicTemplate;
 
     @JsonProperty("kafkaKey")
-    private String kafkaKey;
+    private String kafkaKeyTemplate;
 
     /**
      * Default constructor for MappingRule. Used for deserialization.
@@ -38,10 +38,10 @@ public class MappingRule {
      * @param mqttTopicPattern   the mqtt topic pattern.
      * @param kafkaTopicTemplate the kafka topic template.
      */
-    public MappingRule(String mqttTopicPattern, String kafkaTopicTemplate, String kafkaKey) {
+    public MappingRule(String mqttTopicPattern, String kafkaTopicTemplate, String kafkaKeyTemplate) {
         this.mqttTopicPattern = mqttTopicPattern;
         this.kafkaTopicTemplate = kafkaTopicTemplate;
-        this.kafkaKey = kafkaKey;
+        this.kafkaKeyTemplate = kafkaKeyTemplate;
     }
 
     /**
@@ -67,8 +67,8 @@ public class MappingRule {
      *
      * @return the record key.
      */
-    public String getKafkaKey() {
-        return kafkaKey;
+    public String getKafkaKeyTemplate() {
+        return kafkaKeyTemplate;
     }
 
     /**
@@ -81,7 +81,7 @@ public class MappingRule {
         return "MappingRule(" +
                 "mqttTopicPattern= " + this.mqttTopicPattern +
                 ", kafkaTopicTemplate=" + this.kafkaTopicTemplate +
-                ", kafkaKey=" + this.kafkaKey +
+                ", kafkaKeyTemplate=" + this.kafkaKeyTemplate +
                 ")";
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -22,6 +22,9 @@ public class MappingRule {
     @JsonProperty("kafkaTopic")
     private String kafkaTopicTemplate;
 
+    @JsonProperty("kafkaKey")
+    private String kafkaKey;
+
     /**
      * Default constructor for MappingRule. Used for deserialization.
      */
@@ -34,9 +37,10 @@ public class MappingRule {
      * @param mqttTopicPattern   the mqtt topic pattern.
      * @param kafkaTopicTemplate the kafka topic template.
      */
-    public MappingRule(String mqttTopicPattern, String kafkaTopicTemplate) {
+    public MappingRule(String mqttTopicPattern, String kafkaTopicTemplate, String kafkaKey) {
         this.mqttTopicPattern = mqttTopicPattern;
         this.kafkaTopicTemplate = kafkaTopicTemplate;
+        this.kafkaKey = kafkaKey;
     }
 
     /**
@@ -55,6 +59,15 @@ public class MappingRule {
      */
     public String getMqttTopicPattern() {
         return mqttTopicPattern;
+    }
+
+    /**
+     * Get the record key.
+     *
+     * @return the record key.
+     */
+    public String getKafkaKey() {
+        return kafkaKey;
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Represents a Mapping Rule in the Topic Mapping Rules(ToMaR). Mapping rules are used to define how MQTT topics should be mapped to Kafka topics, and additionally define the record key.
  * E.g.: a valid mapping rule would look like this in the ToMaR file:
  * {
- * "mqttTopic": "sensors/(^[0-9])/type/([^/]+)/data",
- * "kafkaTopic": "sensors_$1_data",
- * "kafkaKey": "sensor_$2"
+ *      "mqttTopic": "sensors/(^[0-9])/type/([^/]+)/data",
+ *      "kafkaTopic": "sensors_$1_data",
+ *      "kafkaKey": "sensor_$2"
  * }
  * and like this in the MappingRule class:
  * MappingRule(mqttTopicPattern= sensors/(^[0-9])/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$2)
@@ -36,7 +36,8 @@ public class MappingRule {
      * Constructor for MappingRule.
      *
      * @param mqttTopicPattern   the mqtt topic pattern.
-     * @param kafkaTopicTemplate the kafka topic template.
+     * @param kafkaTopicTemplate the Kafka topic template.
+     * @param kafkaKeyTemplate   the Kafka key template.
      */
     public MappingRule(String mqttTopicPattern, String kafkaTopicTemplate, String kafkaKeyTemplate) {
         this.mqttTopicPattern = mqttTopicPattern;
@@ -45,9 +46,9 @@ public class MappingRule {
     }
 
     /**
-     * Get the kafka topic template.
+     * Get the Kafka topic template.
      *
-     * @return the kafka topic template.
+     * @return the Kafka topic template.
      */
     public String getKafkaTopicTemplate() {
         return kafkaTopicTemplate;
@@ -65,7 +66,7 @@ public class MappingRule {
     /**
      * Get the record key.
      *
-     * @return the record key.
+     * @return the record key template.
      */
     public String getKafkaKeyTemplate() {
         return kafkaKeyTemplate;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRule.java
@@ -7,14 +7,15 @@ package io.strimzi.kafka.bridge.mqtt.mapper;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Represents a Mapping Rule in the Topic Mapping Rules(TOMAR). Mapping rules are used to define how MQTT topics should be mapped to Kafka topics.
- * E.g.: a valid mapping rule would look like this in the TOMAR file:
+ * Represents a Mapping Rule in the Topic Mapping Rules(ToMaR). Mapping rules are used to define how MQTT topics should be mapped to Kafka topics, and additionally define the record key.
+ * E.g.: a valid mapping rule would look like this in the ToMaR file:
  * {
- *      "mqttTopic": "sensors/{sensorId}/data",
- *      "kafkaTopic": "sensors_{sensorId}_data"
+ * "mqttTopic": "sensors/(^[0-9])/data",
+ * "kafkaTopic": "sensors_$1_data",
+ * "kafkaKey": "sensor_$1"
  * }
  * and like this in the MappingRule class:
- * MappingRule(mqttTopicPattern= sensors/{sensorId}/data, kafkaTopicTemplate=sensors_{sensorId}_data)
+ * MappingRule(mqttTopicPattern= sensors/(^[0-9])/data, kafkaTopicTemplate=sensors_$1_data, kafkaKey=sensor_$1)
  */
 public class MappingRule {
     @JsonProperty("mqttTopic")
@@ -80,6 +81,7 @@ public class MappingRule {
         return "MappingRule(" +
                 "mqttTopicPattern= " + this.mqttTopicPattern +
                 ", kafkaTopicTemplate=" + this.kafkaTopicTemplate +
+                ", kafkaKey=" + this.kafkaKey +
                 ")";
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -42,8 +42,9 @@ public class MqttKafkaMapper {
      * Maps an MQTT topic to a Kafka topic. The topic is mapped according to the defined mapping rules.
      *
      * @param mqttTopic represents an MQTT topic.
-     * @return a valid Kafka topic.
+     * @return a MappingResult object containing the mapped kafka topic and kafka key.
      * @see MappingRule
+     * @see MappingResult
      */
     public MappingResult map(String mqttTopic) {
         MappingResult mappingResult = new MappingResult(DEFAULT_KAFKA_TOPIC, null);

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -16,6 +16,12 @@ public abstract class MqttKafkaMapper {
     // default Kafka topic. Used when no mapping rule matches the mqtt topic.
     public static final String DEFAULT_KAFKA_TOPIC = "messages_default";
 
+    // used to replace the # in the mqtt pattern.
+    public static final String WILDCARD_REGEX = "(?:\\/.*)?$";
+
+    // MQTT topic separator
+    public static final String MQTT_TOPIC_SEPARATOR = "/";
+
     protected final List<MappingRule> rules;
     protected final List<Pattern> patterns = new ArrayList<>();
     protected final Pattern placeholderPattern;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -20,6 +20,13 @@ public abstract class MqttKafkaMapper {
     protected final List<Pattern> patterns = new ArrayList<>();
     protected final Pattern placeholderPattern;
 
+    /**
+     * Constructor
+     *
+     * @param rules the list of mapping rules.
+     * @param placeholderPattern the pattern used to find placeholders.
+     * @see MappingRule
+     */
     protected MqttKafkaMapper(List<MappingRule> rules, Pattern placeholderPattern) {
         this.rules = rules;
         this.placeholderPattern = placeholderPattern;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -4,90 +4,38 @@
  */
 package io.strimzi.kafka.bridge.mqtt.mapper;
 
-import java.util.List;
 import java.util.ArrayList;
-import java.util.regex.Matcher;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * Responsible for handling all the topic mapping.
- *
- * @see MappingRule
+ * Interface for the MqttKafkaMapper. The MqttKafkaMapper is responsible for mapping MQTT topics to Kafka topics.
  */
-public class MqttKafkaMapper {
+public abstract class MqttKafkaMapper {
 
     // default kafka topic. Used when no mapping rule matches the mqtt topic.
     public static final String DEFAULT_KAFKA_TOPIC = "messages_default";
 
-    // used to find any expression starting with a $ followed by upto 2 digits number. E.g. $1, this is known as a placeholder.
-    private static final String MQTT_TOPIC_PLACEHOLDER_REGEX = "\\$(\\d{1,2})";
+    protected final List<MappingRule> rules;
+    protected final List<Pattern> patterns = new ArrayList<>();
+    protected final Pattern placeholderPattern;
 
-    private final List<MappingRule> rules;
-    private final List<Pattern> patterns = new ArrayList<>();
-    private final Pattern placeholderPattern;
-
-    /**
-     * Constructor
-     * Creates a new instance of MqttKafkaMapper.
-     */
-    public MqttKafkaMapper(List<MappingRule> rules) {
+    protected MqttKafkaMapper(List<MappingRule> rules, Pattern placeholderPattern) {
         this.rules = rules;
-        this.placeholderPattern = Pattern.compile(MQTT_TOPIC_PLACEHOLDER_REGEX);
-
-        // compile the patterns for each rule
-        this.rules.forEach(e -> this.patterns.add(Pattern.compile(e.getMqttTopicPattern())));
+        this.placeholderPattern = placeholderPattern;
+        this.buildOrCompilePatterns();
     }
 
     /**
      * Maps an MQTT topic to a Kafka topic. The topic is mapped according to the defined mapping rules.
      *
-     * @param mqttTopic represents an MQTT topic.
+     * @param mqttTopic
      * @return a MappingResult object containing the mapped kafka topic and kafka key.
-     * @see MappingRule
-     * @see MappingResult
      */
-    public MappingResult map(String mqttTopic) {
-        MappingResult mappingResult = new MappingResult(DEFAULT_KAFKA_TOPIC, null);
-
-        for (MappingRule rule : this.rules) {
-            Matcher matcher = this.patterns.get(this.rules.indexOf(rule)).matcher(mqttTopic);
-            if (matcher.matches()) {
-                String mappedKafkaTopic = rule.getKafkaTopicTemplate();
-                String kafkaKey = rule.getKafkaKey();
-
-                for (int i = 1; i < matcher.groupCount() + 1; i++) {
-                    mappedKafkaTopic = mappedKafkaTopic.replace("$" + i, matcher.group(i));
-                    kafkaKey = kafkaKey != null ? kafkaKey.replace("$" + i, matcher.group(i)) : null;
-                }
-
-                // check for pending placeholders replacement in the kafka topic
-                checkPlaceholder(mappedKafkaTopic);
-                // set the mapped kafka topic to the result
-                mappingResult.setKafkaTopic(mappedKafkaTopic);
-
-                if (kafkaKey != null) {
-                    // check for pending placeholders replacement in the kafka key.
-                    checkPlaceholder(kafkaKey);
-                    // set the mapped kafka key to the result
-                    mappingResult.setKafkaKey(kafkaKey);
-                }
-
-                // return the first match
-                return mappingResult;
-            }
-        }
-        return mappingResult;
-    }
+    public abstract MappingResult map(String mqttTopic);
 
     /**
-     * Checks if there are any pending placeholders in the kafka topic or kafka key.
-     *
-     * @param placeholder the placeholder to check.
+     * Helper method for Building the regex expressions for the mapping rules.
      */
-    private void checkPlaceholder(String placeholder) {
-        Matcher matcher = this.placeholderPattern.matcher(placeholder);
-        if (matcher.find()) {
-            throw new IllegalArgumentException("The placeholder " + matcher.group() + " was not found or assigned any value.");
-        }
-    }
+    protected abstract void buildOrCompilePatterns();
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -16,9 +16,6 @@ public abstract class MqttKafkaMapper {
     // default Kafka topic. Used when no mapping rule matches the mqtt topic.
     public static final String DEFAULT_KAFKA_TOPIC = "messages_default";
 
-    // used to replace the # in the mqtt pattern.
-    public static final String WILDCARD_REGEX = "(?:\\/.*)?$";
-
     // MQTT topic separator
     public static final String MQTT_TOPIC_SEPARATOR = "/";
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  */
 public abstract class MqttKafkaMapper {
 
-    // default kafka topic. Used when no mapping rule matches the mqtt topic.
+    // default Kafka topic. Used when no mapping rule matches the mqtt topic.
     public static final String DEFAULT_KAFKA_TOPIC = "messages_default";
 
     protected final List<MappingRule> rules;
@@ -30,7 +30,7 @@ public abstract class MqttKafkaMapper {
      * Maps an MQTT topic to a Kafka topic. The topic is mapped according to the defined mapping rules.
      *
      * @param mqttTopic
-     * @return a MappingResult object containing the mapped kafka topic and kafka key.
+     * @return a MappingResult object containing the mapped Kafka topic and Kafka key.
      */
     public abstract MappingResult map(String mqttTopic);
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -37,11 +37,11 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
                     kafkaKey = kafkaKey != null ? kafkaKey.replace("$" + i, matcher.group(i)) : null;
                 }
 
-                // check for pending placeholders replacement in the kafka topic
+                // check for pending placeholders replacement in the Kafka topic
                 checkPlaceholder(mappedKafkaTopic);
 
                 if (kafkaKey != null) {
-                    // check for pending placeholders replacement in the kafka key.
+                    // check for pending placeholders replacement in the Kafka key.
                     checkPlaceholder(kafkaKey);
                 }
 
@@ -58,7 +58,7 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
     }
 
     /**
-     * Checks if there are any pending placeholders in the kafka topic or kafka key template.
+     * Checks if there are any pending placeholders in the Kafka topic or Kafka key template.
      *
      * @param template the placeholder to check.
      */

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -18,27 +18,19 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
 
     /**
      * Constructor
-     * Creates a new instance of MqttKafkaSimpleMapper.
+     * Creates a new instance of MqttKafkaRegexMapper.
      */
     public MqttKafkaRegexMapper(List<MappingRule> rules) {
         super(rules, Pattern.compile(MQTT_TOPIC_DOLLAR_PLACEHOLDER_REGEX));
     }
 
-    /**
-     * Maps an MQTT topic to a Kafka topic. The topic is mapped according to the defined mapping rules.
-     *
-     * @param mqttTopic represents an MQTT topic.
-     * @return a MappingResult object containing the mapped kafka topic and kafka key.
-     * @see MappingRule
-     * @see MappingResult
-     */
     @Override
     public MappingResult map(String mqttTopic) {
         for (MappingRule rule : this.rules) {
             Matcher matcher = this.patterns.get(this.rules.indexOf(rule)).matcher(mqttTopic);
             if (matcher.matches()) {
                 String mappedKafkaTopic = rule.getKafkaTopicTemplate();
-                String kafkaKey = rule.getKafkaKey();
+                String kafkaKey = rule.getKafkaKeyTemplate();
 
                 for (int i = 1; i < matcher.groupCount() + 1; i++) {
                     mappedKafkaTopic = mappedKafkaTopic.replace("$" + i, matcher.group(i));
@@ -66,12 +58,12 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
     }
 
     /**
-     * Checks if there are any pending placeholders in the kafka topic or kafka key.
+     * Checks if there are any pending placeholders in the kafka topic or kafka key template.
      *
-     * @param placeholder the placeholder to check.
+     * @param template the placeholder to check.
      */
-    private void checkPlaceholder(String placeholder) {
-        Matcher matcher = this.placeholderPattern.matcher(placeholder);
+    private void checkPlaceholder(String template) {
+        Matcher matcher = this.placeholderPattern.matcher(template);
         if (matcher.find()) {
             throw new IllegalArgumentException("The placeholder " + matcher.group() + " was not found or assigned any value.");
         }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.mapper;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Responsible for handling all the topic mapping rules defined with regular expressions.
+ */
+public class MqttKafkaRegexMapper extends MqttKafkaMapper {
+
+    // used to find any expression starting with a $ followed by upto 2 digits number. E.g. $1, this is known as a placeholder.
+    public static final String MQTT_TOPIC_DOLLAR_PLACEHOLDER_REGEX = "\\$(\\d{1,2})";
+
+    /**
+     * Constructor
+     * Creates a new instance of MqttKafkaSimpleMapper.
+     */
+    public MqttKafkaRegexMapper(List<MappingRule> rules) {
+        super(rules, Pattern.compile(MQTT_TOPIC_DOLLAR_PLACEHOLDER_REGEX));
+    }
+
+    /**
+     * Maps an MQTT topic to a Kafka topic. The topic is mapped according to the defined mapping rules.
+     *
+     * @param mqttTopic represents an MQTT topic.
+     * @return a MappingResult object containing the mapped kafka topic and kafka key.
+     * @see MappingRule
+     * @see MappingResult
+     */
+    @Override
+    public MappingResult map(String mqttTopic) {
+        for (MappingRule rule : this.rules) {
+            Matcher matcher = this.patterns.get(this.rules.indexOf(rule)).matcher(mqttTopic);
+            if (matcher.matches()) {
+                String mappedKafkaTopic = rule.getKafkaTopicTemplate();
+                String kafkaKey = rule.getKafkaKey();
+
+                for (int i = 1; i < matcher.groupCount() + 1; i++) {
+                    mappedKafkaTopic = mappedKafkaTopic.replace("$" + i, matcher.group(i));
+                    kafkaKey = kafkaKey != null ? kafkaKey.replace("$" + i, matcher.group(i)) : null;
+                }
+
+                // check for pending placeholders replacement in the kafka topic
+                checkPlaceholder(mappedKafkaTopic);
+
+                if (kafkaKey != null) {
+                    // check for pending placeholders replacement in the kafka key.
+                    checkPlaceholder(kafkaKey);
+                }
+
+                // return the first match
+                return new MappingResult(mappedKafkaTopic, kafkaKey);
+            }
+        }
+        return new MappingResult(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC, null);
+    }
+
+    @Override
+    protected void buildOrCompilePatterns() {
+        this.rules.forEach(e -> patterns.add(Pattern.compile(e.getMqttTopicPattern())));
+    }
+
+    /**
+     * Checks if there are any pending placeholders in the kafka topic or kafka key.
+     *
+     * @param placeholder the placeholder to check.
+     */
+    private void checkPlaceholder(String placeholder) {
+        Matcher matcher = this.placeholderPattern.matcher(placeholder);
+        if (matcher.find()) {
+            throw new IllegalArgumentException("The placeholder " + matcher.group() + " was not found or assigned any value.");
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -16,9 +16,6 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
     // used to find any expression starting with a $ followed by upto 2 digits number. E.g. $1, this is known as a placeholder.
     public static final String MQTT_TOPIC_DOLLAR_PLACEHOLDER_REGEX = "\\$(\\d{1,2})";
 
-    // find literal equivalent of # in the mqtt pattern. E.g. sensors/.*
-    protected static final String PATTERN_MULTI_LEVEL_WILDCARD_REGEX = ".*";
-
     /**
      * Constructor
      * Creates a new instance of MqttKafkaRegexMapper.
@@ -57,22 +54,7 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
 
     @Override
     protected void buildOrCompilePatterns() {
-        for (MappingRule rule : this.rules) {
-            int lastSlashIndex = rule.getMqttTopicPattern().length() - 3;
-            if (rule.getMqttTopicPattern().endsWith(PATTERN_MULTI_LEVEL_WILDCARD_REGEX) && rule.getMqttTopicPattern().split(MQTT_TOPIC_SEPARATOR).length > 1 && rule.getMqttTopicPattern().charAt(lastSlashIndex) == MQTT_TOPIC_SEPARATOR.charAt(0)){
-                // remove /.* from the end of the pattern
-                String regex = rule.getMqttTopicPattern().substring(0, lastSlashIndex) +
-                        // add the wildcard regex
-                        MqttKafkaRegexMapper.WILDCARD_REGEX;
-                this.patterns.add(Pattern.compile(regex));
-            } else if(rule.getMqttTopicPattern().endsWith("("+PATTERN_MULTI_LEVEL_WILDCARD_REGEX+")")){
-                throw new IllegalArgumentException("The pattern " + rule.getMqttTopicPattern() + " is not valid. You should not use .* in capture groups.\n" +
-                        "Example of correct use of .* are: building.*, building/.*, and etc.\n"+
-                        "Please refer to the documentation for more information.");
-            } else {
-                this.patterns.add(Pattern.compile(rule.getMqttTopicPattern()));
-            }
-        }
+        this.rules.forEach(rule-> this.patterns.add(Pattern.compile(rule.getMqttTopicPattern())));
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -31,9 +31,6 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
     // identifies a multi level wildcard character in the mqtt pattern. E.g. sensors/#
     private static final String MQTT_TOPIC_MULTI_LEVEL_WILDCARD_CHARACTER = "#";
 
-    // matches any character after the string. Used to replace the # in the mqtt pattern.
-    private static final String MULTIPLE_LEVEL_WILDCARD_REGEX = ".*";
-
 
     /**
      * Constructor.
@@ -108,7 +105,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
         String[] mqttTopicPatternParts;
         StringBuilder ruleRegex;
         for (MappingRule rule : this.rules) {
-            mqttTopicPatternParts = rule.getMqttTopicPattern().split("/");
+            mqttTopicPatternParts = rule.getMqttTopicPattern().split(MQTT_TOPIC_SEPARATOR);
             ruleRegex = new StringBuilder();
             for (String part : mqttTopicPatternParts) {
                 if (part.matches(MQTT_TOPIC_PLACEHOLDER_REGEX)) {
@@ -119,11 +116,11 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
                     if (ruleRegex.length() > 1) {
                         ruleRegex.deleteCharAt(ruleRegex.length() - 1);
                     }
-                    ruleRegex.append(MULTIPLE_LEVEL_WILDCARD_REGEX);
+                    ruleRegex.append(MqttKafkaMapper.WILDCARD_REGEX);
                 } else {
                     ruleRegex.append(part);
                 }
-                ruleRegex.append("/");
+                ruleRegex.append(MQTT_TOPIC_SEPARATOR);
             }
             // remove the last slash
             ruleRegex.deleteCharAt(ruleRegex.length() - 1);

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -11,9 +11,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Responsible for handling all the topic mapping.
+ * Responsible for handling all the topic mapping using named placeholders instead of regular expressions.
  *
  * @see MappingRule
+ * @see MqttKafkaMapper
+ * @see MqttKafkaRegexMapper
  */
 public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.mapper;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Responsible for handling all the topic mapping.
+ *
+ * @see MappingRule
+ */
+public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
+
+    // find any word inside a curly bracket. E.g. {something}, this is known as a placeholder.
+    private static final String MQTT_TOPIC_PLACEHOLDER_REGEX = "\\{\\w+\\}";
+
+    // identifies a single level wildcard character in the mqtt pattern. E.g. sensors/+/data
+    private static final String MQTT_TOPIC_SINGLE_LEVEL_WILDCARD_CHARACTER = "+";
+
+    // Regex expression used to replace the + in the mqtt pattern.
+    private static final String SINGLE_LEVEL_WILDCARD_REGEX = "[^/]+";
+
+    // identifies a multi level wildcard character in the mqtt pattern. E.g. sensors/#
+    private static final String MQTT_TOPIC_MULTI_LEVEL_WILDCARD_CHARACTER = "#";
+
+    // matches any character after the string. Used to replace the # in the mqtt pattern.
+    private static final String MULTIPLE_LEVEL_WILDCARD_REGEX = ".*";
+
+
+    /**
+     * Constructor.
+     *
+     * @param rules the list of mapping rules.
+     */
+    public MqttKafkaSimpleMapper(List<MappingRule> rules) {
+        super(rules, Pattern.compile(MQTT_TOPIC_PLACEHOLDER_REGEX));
+    }
+
+    @Override
+    public MappingResult map(String mqttTopic) {
+        for (MappingRule rule : this.rules) {
+            Matcher matcher = this.patterns.get(this.rules.indexOf(rule)).matcher(mqttTopic);
+
+            if (matcher.matches()) {
+                HashMap<String, String> placeholders = new HashMap<>();
+
+                String mappedKafkaTopic = rule.getKafkaTopicTemplate();
+                String kafkaKey = rule.getKafkaKey();
+
+                // find MQTT_TOPIC_PLACEHOLDER_REGEX in the kafkaTopicTemplate.
+                Matcher placeholderMatcher = this.placeholderPattern.matcher(rule.getKafkaTopicTemplate());
+                while (placeholderMatcher.find()) {
+                    String placeholderKey = placeholderMatcher.group();
+                    placeholders.put(placeholderKey, null);
+                }
+
+                // find MQTT_TOPIC_PLACEHOLDER_REGEX in the kafkaKey
+                if (kafkaKey != null) {
+                    placeholderMatcher = this.placeholderPattern.matcher(kafkaKey);
+                    while (placeholderMatcher.find()) {
+                        String placeholderKey = placeholderMatcher.group();
+                        placeholders.put(placeholderKey, null);
+                    }
+                }
+
+                if (!placeholders.isEmpty()) {
+                    Matcher mqttTopicMatcher = this.placeholderPattern.matcher(rule.getMqttTopicPattern());
+
+                    // find the placeholders in the mqtt topic pattern and assign them a value.
+                    while (mqttTopicMatcher.find()) {
+                        String placeholderKey = mqttTopicMatcher.group();
+                        String placeholderValue = matcher.group(removeBrackets(placeholderKey));
+                        placeholders.put(placeholderKey, placeholderValue);
+                    }
+
+                    //build the kafka topic using the placeholders.
+                    for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+                        if (entry.getValue() != null) {
+                            mappedKafkaTopic = mappedKafkaTopic.replace(entry.getKey(), entry.getValue());
+                            kafkaKey = kafkaKey != null ? kafkaKey.replace(entry.getKey(), entry.getValue()) : null;
+                        } else {
+                            throw new IllegalArgumentException("The placeholder " + entry.getKey() + " was not found assigned any value.");
+                        }
+                    }
+                }
+                return new MappingResult(mappedKafkaTopic, kafkaKey);
+            }
+        }
+        return new MappingResult(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC, null);
+    }
+
+    @Override
+    protected void buildOrCompilePatterns() {
+
+        //convert the mqtt patterns to a valid regex expression.
+        // the mqtt pattern can contain placeholders like {something}, + and #.
+        // if the mqtt topic contains a +, we replace it with @singleLevelWildcardRegex
+        // if the mqtt topic contains a #, we replace it with @multiLevelWildcardRegex
+        // if the mqtt topic contains a placeholder (pattern \{\w+\}), we replace it with @placeholderRegex
+        String[] mqttTopicPatternParts;
+        StringBuilder ruleRegex;
+        for (MappingRule rule : this.rules) {
+            mqttTopicPatternParts = rule.getMqttTopicPattern().split("/");
+            ruleRegex = new StringBuilder();
+            for (String part : mqttTopicPatternParts) {
+                if (part.matches(MQTT_TOPIC_PLACEHOLDER_REGEX)) {
+                    ruleRegex.append(buildNamedRegexExpression(part));
+                } else if (part.equals(MQTT_TOPIC_SINGLE_LEVEL_WILDCARD_CHARACTER)) {
+                    ruleRegex.append(SINGLE_LEVEL_WILDCARD_REGEX);
+                } else if (part.equals(MQTT_TOPIC_MULTI_LEVEL_WILDCARD_CHARACTER)) {
+                    if (ruleRegex.length() > 1) {
+                        ruleRegex.deleteCharAt(ruleRegex.length() - 1);
+                    }
+                    ruleRegex.append(MULTIPLE_LEVEL_WILDCARD_REGEX);
+                } else {
+                    ruleRegex.append(part);
+                }
+                ruleRegex.append("/");
+            }
+            // remove the last slash
+            ruleRegex.deleteCharAt(ruleRegex.length() - 1);
+            // compile the regex expression for the rule.
+            patterns.add(Pattern.compile(ruleRegex.toString()));
+        }
+    }
+
+    /**
+     * Helper method for building a named regex expression.
+     * A named regex expression is a regex expression that contains a named capturing group.
+     * E.g. (?<groupName>regexExpression)
+     *
+     * @param placeholder represents a placeholder in the mqtt pattern.
+     * @return a named regex expression.
+     */
+    private String buildNamedRegexExpression(String placeholder) {
+        String groupName = removeBrackets(placeholder);
+        return "(?<" + groupName + ">[^/]+)";
+    }
+
+    /**
+     * Helper method for removing the curly brackets from a placeholder.
+     *
+     * @param placeholder represents a placeholder in the pattern.
+     * @return a placeholder without the curly brackets.
+     */
+    private String removeBrackets(String placeholder) {
+        return placeholder.replaceAll("\\{+|\\}+", "");
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -31,6 +31,8 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
     // identifies a multi level wildcard character in the mqtt pattern. E.g. sensors/#
     private static final String MQTT_TOPIC_MULTI_LEVEL_WILDCARD_CHARACTER = "#";
 
+    // used to replace the # in the mqtt pattern.
+    public static final String WILDCARD_REGEX = "(?:\\/.*)?$";
 
     /**
      * Constructor.
@@ -116,7 +118,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
                     if (ruleRegex.length() > 1) {
                         ruleRegex.deleteCharAt(ruleRegex.length() - 1);
                     }
-                    ruleRegex.append(MqttKafkaMapper.WILDCARD_REGEX);
+                    ruleRegex.append(WILDCARD_REGEX);
                 } else {
                     ruleRegex.append(part);
                 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -81,7 +81,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
                         placeholders.put(placeholderKey, placeholderValue);
                     }
 
-                    //build the kafka topic using the placeholders.
+                    // build the Kafka topic using the placeholders.
                     for (Map.Entry<String, String> entry : placeholders.entrySet()) {
                         if (entry.getValue() != null) {
                             mappedKafkaTopic = mappedKafkaTopic.replace(entry.getKey(), entry.getValue());
@@ -100,7 +100,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
     @Override
     protected void buildOrCompilePatterns() {
 
-        //convert the mqtt patterns to a valid regex expression.
+        // convert the mqtt patterns to a valid regex expression.
         // the mqtt pattern can contain placeholders like {something}, + and #.
         // if the mqtt topic contains a +, we replace it with @singleLevelWildcardRegex
         // if the mqtt topic contains a #, we replace it with @multiLevelWildcardRegex

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -51,7 +51,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
                 HashMap<String, String> placeholders = new HashMap<>();
 
                 String mappedKafkaTopic = rule.getKafkaTopicTemplate();
-                String kafkaKey = rule.getKafkaKey();
+                String kafkaKey = rule.getKafkaKeyTemplate();
 
                 // find MQTT_TOPIC_PLACEHOLDER_REGEX in the kafkaTopicTemplate.
                 Matcher placeholderMatcher = this.placeholderPattern.matcher(rule.getKafkaTopicTemplate());

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/core/utils/MappingRulesLoaderTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/core/utils/MappingRulesLoaderTest.java
@@ -34,7 +34,7 @@ public class MappingRulesLoaderTest {
      */
     @Test
     public void testLoadRules() throws Exception {
-        String filePath = Objects.requireNonNull(getClass().getClassLoader().getResource("mapping-rules.json")).getPath();
+        String filePath = Objects.requireNonNull(getClass().getClassLoader().getResource("mapping-rules-regex.json")).getPath();
         MappingRulesLoader loader = mock(MappingRulesLoader.class);
 
         // 1st loadRules call throws exception. 2nd loadRules call returns the rules
@@ -72,7 +72,7 @@ public class MappingRulesLoaderTest {
      */
     @Test
     public void testInitMoreThanOnce() {
-        String filePath = Objects.requireNonNull(getClass().getClassLoader().getResource("mapping-rules.json")).getPath();
+        String filePath = Objects.requireNonNull(getClass().getClassLoader().getResource("mapping-rules-regex.json")).getPath();
         MappingRulesLoader loader = mock(MappingRulesLoader.class);
 
         // 1st init call, do Nothing. 2nd init call throw exception

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapperTest.java
@@ -8,11 +8,14 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 
 /**
  * Unit tests for {@link MqttKafkaMapper}
@@ -32,7 +35,10 @@ public class MqttKafkaMapperTest {
         MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
 
         assertThat("Should use the default topic when no mapping pattern matches.",
-                mapper.map("sensor/temperature"), is(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC));
+                mapper.map("sensor/temperature").getKafkaTopic(), is(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC));
+
+        assertThat("The key for the default topic should be null",
+                mapper.map("sensor/temperature").getKafkaKey(), nullValue());
     }
 
     /**
@@ -42,28 +48,56 @@ public class MqttKafkaMapperTest {
     public void testSingleLevel() {
         List<MappingRule> rules = new ArrayList<>();
 
-        rules.add(new MappingRule("sensors/+/data", "sensor_data"));
-        rules.add(new MappingRule("devices/{device}/data", "devices_{device}_data"));
-        rules.add(new MappingRule("fleet/{fleet}/vehicle/{vehicle}", "fleet_{fleet}"));
-        rules.add(new MappingRule("building/{building}/floor/{floor}", "building.{building}.floor.{floor}"));
-        rules.add(new MappingRule("term/{number}", "term{number}"));
+        rules.add(new MappingRule("sensors/[^/]+/data", "sensor_data", null));
+        rules.add(new MappingRule("devices/([^/]+)/data", "devices_$1_data", "device_$1"));
+        rules.add(new MappingRule("fleet/([0-9]+)/vehicle/(\\w+)", "fleet_$1", "fleet$2"));
+        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$2_$1", "building_$1"));
+        rules.add(new MappingRule("term/(\\d+)", "term$1", "my_term_key_$1"));
+        rules.add(new MappingRule("devices/([^/]+)/data/(\\b(all|new|old)\\b)", "devices_$1_$2_data", "device_$1"));
 
         MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
+        MappingResult mappingResult = mapper.map("building/4/floor/25");
 
-        assertThat("Mqtt pattern sensors/+/data should be mapped to sensor_data",
-                mapper.map("sensors/4/data"), is("sensor_data"));
+        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$2_$1",
+                mappingResult.getKafkaTopic(), is("building_25_4"));
 
-        assertThat("Mqtt pattern devices/{device}/data should be mapped to devices_{device}_data",
-                mapper.map("devices/4/data"), is("devices_4_data"));
+        assertThat("The key for building_$2 should be expanded to building_25",
+                mappingResult.getKafkaKey(), is("building_4"));
 
-        assertThat("Mqtt pattern fleet/{fleet}/vehicle/{vehicle} should be mapped to fleet_{fleet}",
-                mapper.map("fleet/4/vehicle/23"), is("fleet_4"));
+        mappingResult = mapper.map("sensors/temperature/data");
 
-        assertThat("building/{building}/floor/{floor} should be mapped to building.{building}.floor.{floor}",
-                mapper.map("building/4/floor/23"), is("building.4.floor.23"));
+        assertThat("sensors/[^/]+/data should be mapped to sensor_data",
+                mappingResult.getKafkaTopic(), is("sensor_data"));
 
-        assertThat("Mqtt pattern term/{number} should be mapped to term{number}",
-                mapper.map("term/4"), is("term4"));
+        assertThat("The key for the rule sensors/[^/]+/data should be null",
+                mappingResult.getKafkaKey(), nullValue());
+
+        mappingResult = mapper.map("devices/123/data");
+
+        assertThat("devices/[^/]+/data should be mapped to devices_$1_data",
+                mappingResult.getKafkaTopic(), is("devices_123_data"));
+
+        assertThat("The key for devices/[^/]+/data should be device_$1",
+                mappingResult.getKafkaKey(), is("device_123"));
+
+        mappingResult = mapper.map("fleet/4/vehicle/23");
+
+        assertThat("fleet/([0-9]+)/vehicle/(\\w+) should be mapped to fleet_$1",
+                mappingResult.getKafkaTopic(), is("fleet_4"));
+
+        assertThat("The key for fleet/([0-9]+)/vehicle/(\\w+) should be fleet$2",
+                mappingResult.getKafkaKey(), is("fleet23"));
+
+        mappingResult = mapper.map("term/4");
+
+        assertThat("term/(\\d+) should be mapped to term$1",
+                mappingResult.getKafkaTopic(), is("term4"));
+
+        assertThat("The key for term/(\\d+) should be my_term_key_$1",
+                mappingResult.getKafkaKey(), is("my_term_key_4"));
+
+        assertThat("devices/([^/]+)/data/(\\b(all|new|old)\\b) should be mapped to devices_$1_data",
+                mapper.map("devices/bluetooth/data/all").getKafkaTopic(), is("devices_bluetooth_all_data"));
     }
 
 
@@ -74,24 +108,29 @@ public class MqttKafkaMapperTest {
     public void testIllegalPlaceholder() {
 
         List<MappingRule> rules = new ArrayList<>();
-        rules.add(new MappingRule("fleet/{flee}/vehicle/{vehicle}", "fleet_{fleet}"));
-        rules.add(new MappingRule("buildings/+/rooms/+/device/+", "buildings_{building}_rooms_{room}_device_{device}"));
-        rules.add(new MappingRule("building/{building}/room/{room}", "building_{building}_room_{room}_{noexistingplaceholder}"));
+        rules.add(new MappingRule("fleet/vehicle/(\\d+)", "fleet_$1", "fleet_$2_$1"));
+        rules.add(new MappingRule("buildings/([^/]+)/rooms/([^/]+)/device/([^/]+)", "buildings_$0_rooms_$1_device_$2", null));
+        rules.add(new MappingRule("building/(\\d{1,2})/room/(\\d{1,4})", "building_$1_room_$2_$3", null));
 
         MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> mapper.map("fleet/4/vehicle/23"));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> mapper.map("fleet/vehicle/23"));
 
-        String expectedMessage = "The placeholder {fleet} was not found assigned any value.";
+        String expectedMessage = "The placeholder $2 was not found or assigned any value.";
         assertThat("The exception message should be: " + expectedMessage,
                 exception.getMessage(), is(expectedMessage));
 
         Exception otherException = assertThrows(IllegalArgumentException.class, () -> mapper.map("buildings/10/rooms/5/device/3"));
 
-        String otherExpectedMessage = "The placeholder {device} was not found assigned any value.";
+        String otherExpectedMessage = "The placeholder $0 was not found or assigned any value.";
         assertThat("The exception message should be: " + otherExpectedMessage,
                 otherException.getMessage(), is(otherExpectedMessage));
 
+        Exception anotherException = assertThrows(IllegalArgumentException.class, () -> mapper.map("building/10/room/403"));
+
+        String anotherExpectedMessage = "The placeholder $3 was not found or assigned any value.";
+        assertThat("The exception message should be: " + anotherExpectedMessage,
+                anotherException.getMessage(), is(anotherExpectedMessage));
     }
 
     /**
@@ -101,65 +140,102 @@ public class MqttKafkaMapperTest {
     public void testMultiLevel() {
         List<MappingRule> rules = new ArrayList<>();
 
-        rules.add(new MappingRule("building/{building}/room/{room}/#", "building_{building}_room_{room}"));
-        rules.add(new MappingRule("building/{building}/#", "building_{building}_others"));
-        rules.add(new MappingRule("building/#", "building_others"));
-        rules.add(new MappingRule("fleet/{fleet}/vehicle/{vehicle}/#", "fleet_{vehicle}"));
-        rules.add(new MappingRule("sensor/#", "sensor_data"));
-        rules.add(new MappingRule("sport/tennis/{player}/#", "sports_{player}"));
-        rules.add(new MappingRule("+/recipes/#", "my_recipes"));
-        rules.add(new MappingRule("{house}/#", "{house}"));
+        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1_room_$2", "building_$1"));
+        rules.add(new MappingRule("building/([^/]+).*", "building_$1_others", "$1"));
+        rules.add(new MappingRule("building.*", "building_others", null));
+        rules.add(new MappingRule("fleet/([0-9])/vehicle/(\\w+).*", "fleet_$1", "fleet$1"));
+        rules.add(new MappingRule("sensor.*", "sensor_data", "sensor"));
+        rules.add(new MappingRule("sport/tennis/(\\w+).*", "sports_$1", null));
+        rules.add(new MappingRule("(\\w+)/recipes.*", "$1_recipes", "$1"));
+        rules.add(new MappingRule("([^/]+).*", "$1", null));
 
         MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
 
-        // Test fleet/{fleet}/vehicle/{vehicle}/# pattern
-        assertThat("Mqtt topic pattern fleet/{fleet}/vehicle/{vehicle}/# should be mapped to fleet_{vehicle}",
-                mapper.map("fleet/4/vehicle/23/velocity"), is("fleet_23"));
+        // Test for building/([^/]+)/room/(\\d{1,3}).* pattern
+        MappingResult mappingResult = mapper.map("building/4/room/23/temperature");
 
-        // Test building/{building}/room/{room}/# pattern
-        assertThat("Mqtt pattern building/{building}/room/{room}/# should be mapped to building_{building}_room_{room}",
-                mapper.map("building/4/room/23/temperature"), is("building_4_room_23"));
+        assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3}).* should be mapped to building_$1_room_$2",
+                mappingResult.getKafkaTopic(), is("building_4_room_23"));
 
-        // Test building/{building}/# pattern
-        assertThat("Mqtt pattern building/{building}/# should be mapped to building_{building}_others",
-                mapper.map("building/405/room"), is("building_405_others"));
+        assertThat("The key for building/([^/]+)/room/(\\d{1,3}).* should be expanded to building_$1",
+                mappingResult.getKafkaKey(), is("building_4"));
 
-        assertThat("Mqtt pattern building/# will be mapped to building_101_others because building/{building}/# was defined before building/#",
-                mapper.map("building/101"), not("building_others"));
+        // Test for building/([^/]+).* pattern
+        mappingResult = mapper.map("building/405/room");
 
-        // Test building/# pattern
-        assertThat("Mqtt pattern building/# should be mapped to building_others",
-                mapper.map("building"), is("building_others"));
+        assertThat("Mqtt pattern building/([^/]+).* should be mapped to building_$1_others",
+                mappingResult.getKafkaTopic(), is("building_405_others"));
 
-        // Test sensor/# pattern
-        assertThat("Mqtt pattern sensor/# should be mapped to sensor_data",
-                mapper.map("sensor/temperature"), is("sensor_data"));
+        assertThat("The key for building/([^/]+).* should be expanded to building_$1",
+                mappingResult.getKafkaKey(), not("4"));
 
-        // Test sport/tennis/{player}/# pattern
-        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
-                mapper.map("sport/tennis/player1"), is("sports_player1"));
+        // Test for building.* pattern
+        mappingResult = mapper.map("building/101");
 
-        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
-                mapper.map("sport/tennis/player100/ranking"), is("sports_player100"));
+        assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
+                mappingResult.getKafkaTopic(), not("building_others"));
 
-        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
-                mapper.map("sport/tennis/player123/score/wimbledon"), is("sports_player123"));
+        assertThat("building.* should be mapped to building_others",
+                mapper.map("building").getKafkaTopic(), is("building_others"));
 
-        // Test +/recipes/# pattern
-        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
-                mapper.map("italian/recipes/pizza"), is("my_recipes"));
+        // Test for fleet/([0-9])/vehicle/(\\w+).* pattern
+        mappingResult = mapper.map("fleet/9/vehicle/23/velocity");
 
-        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
-                mapper.map("italian/recipes/pasta"), is("my_recipes"));
+        assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+).* should be mapped to fleet_$1",
+                mappingResult.getKafkaTopic(), is("fleet_9"));
 
-        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
-                mapper.map("angolan/recipes/calulu/fish"), is("my_recipes"));
+        assertThat("The key for fleet/([0-9])/vehicle/(\\w+).* should be expanded to fleet$1",
+                mappingResult.getKafkaKey(), is("fleet9"));
 
-        // Test {house}/# pattern
-        assertThat("Mqtt pattern {house}/# should be mapped to {house}",
-                mapper.map("my_house/temperature"), is("my_house"));
+        // Test for sensor.* pattern
+        mappingResult = mapper.map("sensors/temperature/data");
 
-        assertThat("Mqtt pattern {house}/# should be mapped to {house}",
-                mapper.map("my_house/temperature/room1"), is("my_house"));
+        assertThat("Mqtt pattern sensor.* should be mapped to sensor_data",
+                mappingResult.getKafkaTopic(), is("sensor_data"));
+
+        assertThat("The key for sensor.* should be expanded to sensor",
+                mappingResult.getKafkaKey(), is("sensor"));
+
+        // Test for sport/tennis/(\\w+).* pattern
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+                mapper.map("sport/tennis/player1").getKafkaTopic(), is("sports_player1"));
+
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+                mapper.map("sport/tennis/player100/ranking").getKafkaTopic(), is("sports_player100"));
+
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+                mapper.map("sport/tennis/player123/score/wimbledon").getKafkaTopic(), is("sports_player123"));
+
+        // Test for ([^/]+)/recipes.* pattern
+        mappingResult = mapper.map("angolan/recipes/caculu/fish");
+
+        assertThat("Mqtt pattern ([^/]+)/recipes.* should be mapped to my_recipes",
+                mappingResult.getKafkaTopic(), is("angolan_recipes"));
+
+        assertThat("The key for ([^/]+)/recipes.* should be expanded to $1",
+                mappingResult.getKafkaKey(), is("angolan"));
+
+        // Test for ([^/]+).* pattern
+        mappingResult = mapper.map("my_house/temperature");
+
+        assertThat("Mqtt pattern ([^/]+).* should be mapped to $1",
+                mappingResult.getKafkaTopic(), is("my_house"));
+    }
+
+    /**
+     * Test mapping with incorrect regex.
+     */
+    @Test
+    public void testIncorrectRegex() {
+        List<MappingRule> rules = new ArrayList<>();
+
+        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1_room_$2", "building_$1"));
+        rules.add(new MappingRule("building/(\\p).*", "building_$1_others", "$1"));
+        rules.add(new MappingRule("building.*", "building_others", null));
+
+        Exception mapper = assertThrows(PatternSyntaxException.class, () -> new MqttKafkaMapper(rules));
+
+        assertThat("Should throw PatternSyntaxException",
+                mapper.getMessage(), startsWith("Unknown character property name {)} near index 12"));
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -65,7 +65,7 @@ public class MqttKafkaRegexMapperTest {
                 mappingResult.kafkaTopic(), is("building_14"));
 
         assertThat("The key for building_$1 should be expanded to room_25",
-                mappingResult.kafkaKey(), is("building_25"));
+                mappingResult.kafkaKey(), is("room_25"));
 
         // Test sensors/[^/]+/data
         mappingResult = mapper.map("sensors/temperature/data");

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 
 /**
- * Unit tests for {@link MqttKafkaSimpleMapper}
+ * Unit tests for {@link MqttKafkaRegexMapper}
  */
 public class MqttKafkaRegexMapperTest {
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -18,9 +18,9 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 
 /**
- * Unit tests for {@link MqttKafkaMapper}
+ * Unit tests for {@link MqttKafkaSimpleMapper}
  */
-public class MqttKafkaMapperTest {
+public class MqttKafkaRegexMapperTest {
 
 
     /**
@@ -32,13 +32,13 @@ public class MqttKafkaMapperTest {
     public void testDefaultTopic() {
         List<MappingRule> rules = new ArrayList<>();
 
-        MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
+        MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
         assertThat("Should use the default topic when no mapping pattern matches.",
-                mapper.map("sensor/temperature").getKafkaTopic(), is(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC));
+                mapper.map("sensor/temperature").kafkaTopic(), is(MqttKafkaSimpleMapper.DEFAULT_KAFKA_TOPIC));
 
         assertThat("The key for the default topic should be null",
-                mapper.map("sensor/temperature").getKafkaKey(), nullValue());
+                mapper.map("sensor/temperature").kafkaKey(), nullValue());
     }
 
     /**
@@ -51,53 +51,44 @@ public class MqttKafkaMapperTest {
         rules.add(new MappingRule("sensors/[^/]+/data", "sensor_data", null));
         rules.add(new MappingRule("devices/([^/]+)/data", "devices_$1_data", "device_$1"));
         rules.add(new MappingRule("fleet/([0-9]+)/vehicle/(\\w+)", "fleet_$1", "fleet$2"));
-        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$2_$1", "building_$1"));
+        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$1_$2", "building_$1"));
         rules.add(new MappingRule("term/(\\d+)", "term$1", "my_term_key_$1"));
         rules.add(new MappingRule("devices/([^/]+)/data/(\\b(all|new|old)\\b)", "devices_$1_$2_data", "device_$1"));
 
-        MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
-        MappingResult mappingResult = mapper.map("building/4/floor/25");
+        MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
-        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$2_$1",
-                mappingResult.getKafkaTopic(), is("building_25_4"));
+        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$1_$2",
+                mapper.map("building/14/floor/25").kafkaTopic(), is("building_14_25"));
 
-        assertThat("The key for building_$2 should be expanded to building_25",
-                mappingResult.getKafkaKey(), is("building_4"));
-
-        mappingResult = mapper.map("sensors/temperature/data");
+        assertThat("The key for building_$1 should be expanded to building_14",
+                mapper.map("building/14/floor/25").kafkaKey(), is("building_14"));
 
         assertThat("sensors/[^/]+/data should be mapped to sensor_data",
-                mappingResult.getKafkaTopic(), is("sensor_data"));
+                mapper.map("sensors/temperature/data").kafkaTopic(), is("sensor_data"));
 
         assertThat("The key for the rule sensors/[^/]+/data should be null",
-                mappingResult.getKafkaKey(), nullValue());
-
-        mappingResult = mapper.map("devices/123/data");
+                mapper.map("sensors/temperature/data").kafkaKey(), nullValue());
 
         assertThat("devices/[^/]+/data should be mapped to devices_$1_data",
-                mappingResult.getKafkaTopic(), is("devices_123_data"));
+                mapper.map("devices/123/data").kafkaTopic(), is("devices_123_data"));
 
         assertThat("The key for devices/[^/]+/data should be device_$1",
-                mappingResult.getKafkaKey(), is("device_123"));
-
-        mappingResult = mapper.map("fleet/4/vehicle/23");
+                mapper.map("devices/123/data").kafkaKey(), is("device_123"));
 
         assertThat("fleet/([0-9]+)/vehicle/(\\w+) should be mapped to fleet_$1",
-                mappingResult.getKafkaTopic(), is("fleet_4"));
+                mapper.map("fleet/4/vehicle/23").kafkaTopic(), is("fleet_4"));
 
         assertThat("The key for fleet/([0-9]+)/vehicle/(\\w+) should be fleet$2",
-                mappingResult.getKafkaKey(), is("fleet23"));
-
-        mappingResult = mapper.map("term/4");
+                mapper.map("fleet/4/vehicle/23").kafkaKey(), is("fleet23"));
 
         assertThat("term/(\\d+) should be mapped to term$1",
-                mappingResult.getKafkaTopic(), is("term4"));
+                mapper.map("term/4").kafkaTopic(), is("term4"));
 
         assertThat("The key for term/(\\d+) should be my_term_key_$1",
-                mappingResult.getKafkaKey(), is("my_term_key_4"));
+                mapper.map("term/4").kafkaKey(), is("my_term_key_4"));
 
         assertThat("devices/([^/]+)/data/(\\b(all|new|old)\\b) should be mapped to devices_$1_data",
-                mapper.map("devices/bluetooth/data/all").getKafkaTopic(), is("devices_bluetooth_all_data"));
+                mapper.map("devices/bluetooth/data/all").kafkaTopic(), is("devices_bluetooth_all_data"));
     }
 
 
@@ -112,7 +103,7 @@ public class MqttKafkaMapperTest {
         rules.add(new MappingRule("buildings/([^/]+)/rooms/([^/]+)/device/([^/]+)", "buildings_$0_rooms_$1_device_$2", null));
         rules.add(new MappingRule("building/(\\d{1,2})/room/(\\d{1,4})", "building_$1_room_$2_$3", null));
 
-        MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
+        MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> mapper.map("fleet/vehicle/23"));
 
@@ -149,77 +140,64 @@ public class MqttKafkaMapperTest {
         rules.add(new MappingRule("(\\w+)/recipes.*", "$1_recipes", "$1"));
         rules.add(new MappingRule("([^/]+).*", "$1", null));
 
-        MqttKafkaMapper mapper = new MqttKafkaMapper(rules);
+        MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
         // Test for building/([^/]+)/room/(\\d{1,3}).* pattern
-        MappingResult mappingResult = mapper.map("building/4/room/23/temperature");
-
         assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3}).* should be mapped to building_$1_room_$2",
-                mappingResult.getKafkaTopic(), is("building_4_room_23"));
+                mapper.map("building/4/room/23/temperature").kafkaTopic(), is("building_4_room_23"));
 
         assertThat("The key for building/([^/]+)/room/(\\d{1,3}).* should be expanded to building_$1",
-                mappingResult.getKafkaKey(), is("building_4"));
+                mapper.map("building/4/room/23/temperature").kafkaKey(), is("building_4"));
 
         // Test for building/([^/]+).* pattern
-        mappingResult = mapper.map("building/405/room");
 
         assertThat("Mqtt pattern building/([^/]+).* should be mapped to building_$1_others",
-                mappingResult.getKafkaTopic(), is("building_405_others"));
+                mapper.map("building/405/room").kafkaTopic(), is("building_405_others"));
 
         assertThat("The key for building/([^/]+).* should be expanded to building_$1",
-                mappingResult.getKafkaKey(), not("4"));
+                mapper.map("building/405/room").kafkaKey(), not("4"));
 
         // Test for building.* pattern
-        mappingResult = mapper.map("building/101");
-
         assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
-                mappingResult.getKafkaTopic(), not("building_others"));
+                mapper.map("building/101").kafkaTopic(), not("building_others"));
 
         assertThat("building.* should be mapped to building_others",
-                mapper.map("building").getKafkaTopic(), is("building_others"));
+                mapper.map("building").kafkaTopic(), is("building_others"));
 
         // Test for fleet/([0-9])/vehicle/(\\w+).* pattern
-        mappingResult = mapper.map("fleet/9/vehicle/23/velocity");
-
         assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+).* should be mapped to fleet_$1",
-                mappingResult.getKafkaTopic(), is("fleet_9"));
+                mapper.map("fleet/9/vehicle/23/velocity").kafkaTopic(), is("fleet_9"));
 
         assertThat("The key for fleet/([0-9])/vehicle/(\\w+).* should be expanded to fleet$1",
-                mappingResult.getKafkaKey(), is("fleet9"));
+                mapper.map("fleet/9/vehicle/23/velocity").kafkaKey(), is("fleet9"));
 
         // Test for sensor.* pattern
-        mappingResult = mapper.map("sensors/temperature/data");
-
         assertThat("Mqtt pattern sensor.* should be mapped to sensor_data",
-                mappingResult.getKafkaTopic(), is("sensor_data"));
+                mapper.map("sensors/temperature/data").kafkaTopic(), is("sensor_data"));
 
         assertThat("The key for sensor.* should be expanded to sensor",
-                mappingResult.getKafkaKey(), is("sensor"));
+                mapper.map("sensors/temperature/data").kafkaKey(), is("sensor"));
 
         // Test for sport/tennis/(\\w+).* pattern
         assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
-                mapper.map("sport/tennis/player1").getKafkaTopic(), is("sports_player1"));
+                mapper.map("sport/tennis/player1").kafkaTopic(), is("sports_player1"));
 
         assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
-                mapper.map("sport/tennis/player100/ranking").getKafkaTopic(), is("sports_player100"));
+                mapper.map("sport/tennis/player100/ranking").kafkaTopic(), is("sports_player100"));
 
         assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
-                mapper.map("sport/tennis/player123/score/wimbledon").getKafkaTopic(), is("sports_player123"));
+                mapper.map("sport/tennis/player123/score/wimbledon").kafkaTopic(), is("sports_player123"));
 
         // Test for ([^/]+)/recipes.* pattern
-        mappingResult = mapper.map("angolan/recipes/caculu/fish");
-
         assertThat("Mqtt pattern ([^/]+)/recipes.* should be mapped to my_recipes",
-                mappingResult.getKafkaTopic(), is("angolan_recipes"));
+                mapper.map("angolan/recipes/caculu/fish").kafkaTopic(), is("angolan_recipes"));
 
         assertThat("The key for ([^/]+)/recipes.* should be expanded to $1",
-                mappingResult.getKafkaKey(), is("angolan"));
+                mapper.map("angolan/recipes/caculu/fish").kafkaKey(), is("angolan"));
 
         // Test for ([^/]+).* pattern
-        mappingResult = mapper.map("my_house/temperature");
-
         assertThat("Mqtt pattern ([^/]+).* should be mapped to $1",
-                mappingResult.getKafkaTopic(), is("my_house"));
+                mapper.map("my_house/temperature").kafkaTopic(), is("my_house"));
     }
 
     /**
@@ -233,9 +211,35 @@ public class MqttKafkaMapperTest {
         rules.add(new MappingRule("building/(\\p).*", "building_$1_others", "$1"));
         rules.add(new MappingRule("building.*", "building_others", null));
 
-        Exception mapper = assertThrows(PatternSyntaxException.class, () -> new MqttKafkaMapper(rules));
+        Exception mapper = assertThrows(PatternSyntaxException.class, () -> new MqttKafkaRegexMapper(rules));
 
         assertThat("Should throw PatternSyntaxException",
                 mapper.getMessage(), startsWith("Unknown character property name {)} near index 12"));
+    }
+
+    /**
+     * Test the order of the regex.
+     */
+    @Test
+    public void testRegexOrder() {
+        List<MappingRule> rules = new ArrayList<>();
+
+        rules.add(new MappingRule("home/(\\w+)/temperature/(sensor\\d{1,2})/readings/(\\b(all|new|old)\\b)", "temperature_$2_in_$1", "$2_$3_data_from_$1"));
+        rules.add(new MappingRule("sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match\\/(\\d+)\\/goal\\/(\\d+)", "season_$2_$1", "$1"));
+
+        MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
+
+        assertThat("Mqtt pattern home/(\\w+)/temperature/(sensor\\d{1,2})/readings/(\\b(all|new|old)\\b) should be mapped to temperature_$2_in_$1",
+                mapper.map("home/bedroom/temperature/sensor01/readings/all").kafkaTopic(), is("temperature_sensor01_in_bedroom"));
+
+        assertThat("The key for home/(\\w+)/temperature/(sensor\\d{1,2})/readings/(\\b(all|new|old)\\b) should be expanded to $2_$3_data_from_$1",
+                mapper.map("home/bedroom/temperature/sensor01/readings/all").kafkaKey(), is("sensor01_all_data_from_bedroom"));
+
+        assertThat("Mqtt pattern sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match\\/(\\d+)\\/goal\\/(\\d+) should be mapped to season_$2_$1",
+                mapper.map("sports/baseball/league/season/2019-2020/match/1/goal/1").kafkaTopic(), is("season_2019-2020_baseball"));
+
+        assertThat("The key for sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match\\/(\\d+)\\/goal\\/(\\d+) should be expanded to $1",
+                mapper.map("sports/baseball/league/season/2019-2020/match/1/goal/1").kafkaKey(), is("baseball"));
+
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -65,7 +65,7 @@ public class MqttKafkaRegexMapperTest {
                 mappingResult.kafkaTopic(), is("building_14"));
 
         assertThat("The key for building_$1 should be expanded to room_25",
-                mappingResult.kafkaKey(), is("room_25"));
+                mappingResult.kafkaKey(), is("floor_25"));
 
         // Test sensors/[^/]+/data
         mappingResult = mapper.map("sensors/temperature/data");

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -52,7 +52,7 @@ public class MqttKafkaRegexMapperTest {
         rules.add(new MappingRule("sensors/[^/]+/data", "sensor_data", null));
         rules.add(new MappingRule("devices/([^/]+)/data", "devices_$1_data", null));
         rules.add(new MappingRule("fleet/([0-9]+)/vehicle/(\\w+)", "fleet_$1", "vehicle$2"));
-        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$1", "building_$2"));
+        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$1", "floor_$2"));
         rules.add(new MappingRule("term/(\\d+)", "term$1", null));
         rules.add(new MappingRule("devices/([^/]+)/data/(\\b(all|new|old)\\b)", "devices_$1_data", "devices_$2"));
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -52,19 +52,19 @@ public class MqttKafkaRegexMapperTest {
         rules.add(new MappingRule("sensors/[^/]+/data", "sensor_data", null));
         rules.add(new MappingRule("devices/([^/]+)/data", "devices_$1_data", null));
         rules.add(new MappingRule("fleet/([0-9]+)/vehicle/(\\w+)", "fleet_$1", "vehicle$2"));
-        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+).*", "building_$1", "floor_$2"));
+        rules.add(new MappingRule("building/(\\d+)/floor/(\\d+)", "building_$1", "floor_$2"));
         rules.add(new MappingRule("term/(\\d+)", "term$1", null));
         rules.add(new MappingRule("devices/([^/]+)/data/(\\b(all|new|old)\\b)", "devices_$1_data", "devices_$2"));
 
         MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
-        // Test building/(\\d+)/floor/(\\d+).*
+        // Test building/(\\d+)/floor/(\\d+)
         MappingResult mappingResult = mapper.map("building/14/floor/25");
 
-        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$1",
+        assertThat("building/(\\d+)/floor/(\\d+) should be mapped to building_$1",
                 mappingResult.kafkaTopic(), is("building_14"));
 
-        assertThat("The key for building_$1 should be expanded to room_25",
+        assertThat("The key for floor_$2 should be expanded to floor_25",
                 mappingResult.kafkaKey(), is("floor_25"));
 
         // Test sensors/[^/]+/data
@@ -153,99 +153,100 @@ public class MqttKafkaRegexMapperTest {
     public void testMultiLevel() {
         List<MappingRule> rules = new ArrayList<>();
 
-        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1_room_$2", "building_$2"));
+        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3})/.*", "building_$1", "room_$2"));
         rules.add(new MappingRule("building/([^/]+).*", "building_$1_others", null));
-        rules.add(new MappingRule("building.*", "building_others", null));
-        rules.add(new MappingRule("fleet/([0-9])/vehicle/(\\w+).*", "fleet_$1", "vehicle_$2"));
+        rules.add(new MappingRule("building/.*", "building_others", null));
+        rules.add(new MappingRule("fleet/([0-9])/vehicle/(\\w+)/.*", "fleet_$1", "vehicle_$2"));
         rules.add(new MappingRule("sensor.*", "sensor_data", null));
-        rules.add(new MappingRule("sport/tennis/(\\w+).*", "sports_$1", null));
-        rules.add(new MappingRule("(\\w+)/recipes.*", "$1_recipes", null));
-        rules.add(new MappingRule("([^/]+).*", "$1", null));
+        rules.add(new MappingRule("sport/tennis/(\\w+)/.*", "sports_$1", null));
+        rules.add(new MappingRule("(\\w+)/recipes/.*", "$1_recipes", null));
+        rules.add(new MappingRule("([^/]+)/.*", "$1", null));
 
         MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
-        // Test for building/([^/]+)/room/(\\d{1,3}).* pattern
+
+        // Test for building/([^/]+)/room/(\\d{1,3})/.* pattern
         MappingResult mappingResult = mapper.map("building/4/room/23/temperature");
 
-        assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3}).* should be mapped to building_$1_room_$2",
-                mappingResult.kafkaTopic(), is("building_4_room_23"));
+        assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3})/.* should be mapped to building_$1",
+                mappingResult.kafkaTopic(), is("building_4"));
 
-        assertThat("The key for building/([^/]+)/room/(\\d{1,3}).* should be expanded to building_$2",
-                mappingResult.kafkaKey(), is("building_23"));
+        assertThat("The key for building/([^/]+)/room/(\\d{1,3})/.* should be expanded to room_$2",
+                mappingResult.kafkaKey(), is("room_23"));
 
         // Test for building/([^/]+).* pattern
         mappingResult = mapper.map("building/405/room");
 
-        assertThat("Mqtt pattern building/([^/]+).* should be mapped to building_$1_others",
+        assertThat("Mqtt pattern building/([^/]+)/.* should be mapped to building_$1_others",
                 mappingResult.kafkaTopic(), is("building_405_others"));
 
-        assertThat("The key for building/([^/]+).* should be expanded to null",
+        assertThat("The key for building/([^/]+)/.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        // Test for building.* pattern
+        // Test for building/.* pattern
         mappingResult = mapper.map("building/101");
 
-        assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
+        assertThat("Mqtt pattern building/.* will be mapped to building_101_others because building/([^/]+)/.* was defined before building/.*",
                 mappingResult.kafkaTopic(), not("building_others"));
 
-        assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
+        assertThat("Mqtt pattern building/.* will be mapped to building_101_others because building/([^/]+)/.* was defined before building/.*",
                 mappingResult.kafkaTopic(), is("building_101_others"));
 
-        assertThat("The key for building.* should be expanded to null",
+        assertThat("The key for building/.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        assertThat("building.* should be mapped to building_others",
+        assertThat("building/.* should be mapped to building_others",
                 mapper.map("building").kafkaTopic(), is("building_others"));
 
-        // Test for fleet/([0-9])/vehicle/(\\w+).* pattern
+        // Test for fleet/([0-9])/vehicle/(\\w+)/.* pattern
         mappingResult = mapper.map("fleet/9/vehicle/23/velocity");
 
-        assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+).* should be mapped to fleet_$1",
+        assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+)/.* should be mapped to fleet_$1",
                 mappingResult.kafkaTopic(), is("fleet_9"));
 
-        assertThat("The key for fleet/([0-9])/vehicle/(\\w+).* should be expanded to fleet$1",
+        assertThat("The key for fleet/([0-9])/vehicle/(\\w+)/.* should be expanded to fleet$1",
                 mappingResult.kafkaKey(), is("vehicle_23"));
 
         // Test for sensor.* pattern
         mappingResult = mapper.map("sensor/temperature/data");
 
-        assertThat("Mqtt pattern sensor.* should be mapped to sensor_data",
+        assertThat("Mqtt pattern sensor/.* should be mapped to sensor_data",
                 mappingResult.kafkaTopic(), is("sensor_data"));
 
         assertThat("The key for sensor.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        // Test for sport/tennis/(\\w+).* pattern
+        // Test for sport/tennis/(\\w+)/.* pattern
         mappingResult = mapper.map("sport/tennis/player123/score/wimbledon");
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
                 mappingResult.kafkaTopic(), is("sports_player123"));
 
-        assertThat("The key for sport/tennis/(\\w+).* should be expanded to null",
+        assertThat("The key for sport/tennis/(\\w+)/.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
                 mapper.map("sport/tennis/player1").kafkaTopic(), is("sports_player1"));
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
                 mapper.map("sport/tennis/player100/ranking").kafkaTopic(), is("sports_player100"));
 
-        // Test for ([^/]+)/recipes.* pattern
+        // Test for ([^/]+)/recipes/.* pattern
         mappingResult = mapper.map("angolan/recipes/caculu/fish");
 
-        assertThat("Mqtt pattern ([^/]+)/recipes.* should be mapped to my_recipes",
+        assertThat("Mqtt pattern ([^/]+)/recipes/.* should be mapped to my_recipes",
                 mappingResult.kafkaTopic(), is("angolan_recipes"));
 
-        assertThat("The key for ([^/]+)/recipes.* should be expanded to null",
+        assertThat("The key for ([^/]+)/recipes/.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        // Test for ([^/]+).* pattern
+        // Test for ([^/]+)/.* pattern
         mappingResult = mapper.map("my_house/temperature");
 
-        assertThat("Mqtt pattern ([^/]+).* should be mapped to $1",
+        assertThat("Mqtt pattern ([^/]+)/.* should be mapped to $1",
                 mappingResult.kafkaTopic(), is("my_house"));
 
-        assertThat("The key for ([^/]+).* should be expanded to null",
+        assertThat("The key for ([^/]+)/.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
     }
 
@@ -256,14 +257,24 @@ public class MqttKafkaRegexMapperTest {
     public void testIncorrectRegex() {
         List<MappingRule> rules = new ArrayList<>();
 
-        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1_room_$2", "building_$1"));
-        rules.add(new MappingRule("building/(\\p).*", "building_$1_others", "$1"));
-        rules.add(new MappingRule("building.*", "building_others", null));
+        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1", "room_$1"));
+        rules.add(new MappingRule("building/(\\p)/.*", "building_$1_others", null));
+        rules.add(new MappingRule("building/.*", "building_others", null));
 
         Exception mapper = assertThrows(PatternSyntaxException.class, () -> new MqttKafkaRegexMapper(rules));
 
         assertThat("Should throw PatternSyntaxException",
                 mapper.getMessage(), startsWith("Unknown character property name {)} near index 12"));
+
+        // test for .* in capture groups
+        rules.add(0, new MappingRule("fleet/([0-9])/vehicle/(\\w+)/(.*)", "fleet_$1", "vehicle_$2"));
+
+        Exception anotherMapper = assertThrows(
+                "Should throw IllegalArgumentException",
+                IllegalArgumentException.class, () -> new MqttKafkaRegexMapper(rules));
+
+        assertThat(".* should not be used in capture groups",
+                anotherMapper.getMessage(), startsWith("The pattern fleet/([0-9])/vehicle/(\\w+)/(.*) is not valid. You should not use .* in capture groups"));
     }
 
     /**
@@ -274,7 +285,7 @@ public class MqttKafkaRegexMapperTest {
         List<MappingRule> rules = new ArrayList<>();
 
         rules.add(new MappingRule("home/(\\w+)/temperature/(sensor\\d{1,2})/readings/(\\b(all|new|old)\\b)", "temperature_$2_in_$1", "$3"));
-        rules.add(new MappingRule("sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match/(\\d+).*", "season_$2_$1", "match_$3"));
+        rules.add(new MappingRule("sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match/(\\d+)/.*", "season_$2_$1", "match_$3"));
 
         MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -64,7 +64,7 @@ public class MqttKafkaRegexMapperTest {
         assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$1_$2",
                 mappingResult.kafkaTopic(), is("building_14"));
 
-        assertThat("The key for building_$1 should be expanded to building_25",
+        assertThat("The key for building_$1 should be expanded to room_25",
                 mappingResult.kafkaKey(), is("building_25"));
 
         // Test sensors/[^/]+/data

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -153,91 +153,91 @@ public class MqttKafkaRegexMapperTest {
     public void testMultiLevel() {
         List<MappingRule> rules = new ArrayList<>();
 
-        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3})/.*", "building_$1", "room_$2"));
+        rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1", "room_$2"));
         rules.add(new MappingRule("building/([^/]+).*", "building_$1_others", null));
-        rules.add(new MappingRule("building/.*", "building_others", null));
-        rules.add(new MappingRule("fleet/([0-9])/vehicle/(\\w+)/.*", "fleet_$1", "vehicle_$2"));
+        rules.add(new MappingRule("building.*", "building_others", null));
+        rules.add(new MappingRule("fleet/([0-9])/vehicle/(\\w+)(?:\\/.*)?$", "fleet_$1", "vehicle_$2"));
         rules.add(new MappingRule("sensor.*", "sensor_data", null));
-        rules.add(new MappingRule("sport/tennis/(\\w+)/.*", "sports_$1", null));
-        rules.add(new MappingRule("(\\w+)/recipes/.*", "$1_recipes", null));
+        rules.add(new MappingRule("sport/tennis/(\\w+).*", "sports_$1", null));
+        rules.add(new MappingRule("(\\w+)/recipes(?:\\/.*)?$", "$1_recipes", null));
         rules.add(new MappingRule("([^/]+)/.*", "$1", null));
 
         MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 
 
-        // Test for building/([^/]+)/room/(\\d{1,3})/.* pattern
+        // Test for building/([^/]+)/room/(\\d{1,3}).* pattern
         MappingResult mappingResult = mapper.map("building/4/room/23/temperature");
 
-        assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3})/.* should be mapped to building_$1",
+        assertThat("Mqtt pattern building/([^/]+)/room/(\\d{1,3}).* should be mapped to building_$1",
                 mappingResult.kafkaTopic(), is("building_4"));
 
-        assertThat("The key for building/([^/]+)/room/(\\d{1,3})/.* should be expanded to room_$2",
+        assertThat("The key for building/([^/]+)/room/(\\d{1,3}).* should be expanded to room_$2",
                 mappingResult.kafkaKey(), is("room_23"));
 
         // Test for building/([^/]+).* pattern
         mappingResult = mapper.map("building/405/room");
 
-        assertThat("Mqtt pattern building/([^/]+)/.* should be mapped to building_$1_others",
+        assertThat("Mqtt pattern building/([^/]+).* should be mapped to building_$1_others",
                 mappingResult.kafkaTopic(), is("building_405_others"));
 
-        assertThat("The key for building/([^/]+)/.* should be expanded to null",
+        assertThat("The key for building/([^/]+).* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        // Test for building/.* pattern
+        // Test for building.* pattern
         mappingResult = mapper.map("building/101");
 
-        assertThat("Mqtt pattern building/.* will be mapped to building_101_others because building/([^/]+)/.* was defined before building/.*",
+        assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
                 mappingResult.kafkaTopic(), not("building_others"));
 
-        assertThat("Mqtt pattern building/.* will be mapped to building_101_others because building/([^/]+)/.* was defined before building/.*",
+        assertThat("Mqtt pattern building.* will be mapped to building_101_others because building/([^/]+).* was defined before building.*",
                 mappingResult.kafkaTopic(), is("building_101_others"));
 
-        assertThat("The key for building/.* should be expanded to null",
+        assertThat("The key for building.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        assertThat("building/.* should be mapped to building_others",
+        assertThat("building.* should be mapped to building_others",
                 mapper.map("building").kafkaTopic(), is("building_others"));
 
-        // Test for fleet/([0-9])/vehicle/(\\w+)/.* pattern
+        // Test for fleet/([0-9])/vehicle/(\\w+)(?:\/.*)?$ pattern
         mappingResult = mapper.map("fleet/9/vehicle/23/velocity");
 
-        assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+)/.* should be mapped to fleet_$1",
+        assertThat("Mqtt pattern fleet/([0-9])/vehicle/(\\w+)(?:\\/.*)?$ should be mapped to fleet_$1",
                 mappingResult.kafkaTopic(), is("fleet_9"));
 
-        assertThat("The key for fleet/([0-9])/vehicle/(\\w+)/.* should be expanded to fleet$1",
+        assertThat("The key for fleet/([0-9])/vehicle/(\\w+)(?:\\/.*)?$ should be expanded to fleet$1",
                 mappingResult.kafkaKey(), is("vehicle_23"));
 
         // Test for sensor.* pattern
         mappingResult = mapper.map("sensor/temperature/data");
 
-        assertThat("Mqtt pattern sensor/.* should be mapped to sensor_data",
+        assertThat("Mqtt pattern sensor.* should be mapped to sensor_data",
                 mappingResult.kafkaTopic(), is("sensor_data"));
 
         assertThat("The key for sensor.* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        // Test for sport/tennis/(\\w+)/.* pattern
+        // Test for sport/tennis/(\\w+).* pattern
         mappingResult = mapper.map("sport/tennis/player123/score/wimbledon");
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
                 mappingResult.kafkaTopic(), is("sports_player123"));
 
-        assertThat("The key for sport/tennis/(\\w+)/.* should be expanded to null",
+        assertThat("The key for sport/tennis/(\\w+).* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
                 mapper.map("sport/tennis/player1").kafkaTopic(), is("sports_player1"));
 
-        assertThat("Mqtt pattern sport/tennis/(\\w+)/.* should be mapped to sports_$1",
+        assertThat("Mqtt pattern sport/tennis/(\\w+).* should be mapped to sports_$1",
                 mapper.map("sport/tennis/player100/ranking").kafkaTopic(), is("sports_player100"));
 
-        // Test for ([^/]+)/recipes/.* pattern
+        // Test for ([^/]+)/recipes(?:\/.*)?$ pattern
         mappingResult = mapper.map("angolan/recipes/caculu/fish");
 
-        assertThat("Mqtt pattern ([^/]+)/recipes/.* should be mapped to my_recipes",
+        assertThat("Mqtt pattern ([^/]+)/recipes(?:\\/.*)?$ should be mapped to my_recipes",
                 mappingResult.kafkaTopic(), is("angolan_recipes"));
 
-        assertThat("The key for ([^/]+)/recipes/.* should be expanded to null",
+        assertThat("The key for ([^/]+)/recipes(?:\\/.*)?$ should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
 
         // Test for ([^/]+)/.* pattern
@@ -246,7 +246,7 @@ public class MqttKafkaRegexMapperTest {
         assertThat("Mqtt pattern ([^/]+)/.* should be mapped to $1",
                 mappingResult.kafkaTopic(), is("my_house"));
 
-        assertThat("The key for ([^/]+)/.* should be expanded to null",
+        assertThat("The key for ([^/]+).* should be expanded to null",
                 mappingResult.kafkaKey(), nullValue());
     }
 
@@ -258,8 +258,8 @@ public class MqttKafkaRegexMapperTest {
         List<MappingRule> rules = new ArrayList<>();
 
         rules.add(new MappingRule("building/([^/]+)/room/(\\d{1,3}).*", "building_$1", "room_$1"));
-        rules.add(new MappingRule("building/(\\p)/.*", "building_$1_others", null));
-        rules.add(new MappingRule("building/.*", "building_others", null));
+        rules.add(new MappingRule("building/(\\p).*", "building_$1_others", null));
+        rules.add(new MappingRule("building.*", "building_others", null));
 
         Exception mapper = assertThrows(PatternSyntaxException.class, () -> new MqttKafkaRegexMapper(rules));
 
@@ -272,9 +272,6 @@ public class MqttKafkaRegexMapperTest {
         Exception anotherMapper = assertThrows(
                 "Should throw IllegalArgumentException",
                 IllegalArgumentException.class, () -> new MqttKafkaRegexMapper(rules));
-
-        assertThat(".* should not be used in capture groups",
-                anotherMapper.getMessage(), startsWith("The pattern fleet/([0-9])/vehicle/(\\w+)/(.*) is not valid. You should not use .* in capture groups"));
     }
 
     /**
@@ -285,7 +282,7 @@ public class MqttKafkaRegexMapperTest {
         List<MappingRule> rules = new ArrayList<>();
 
         rules.add(new MappingRule("home/(\\w+)/temperature/(sensor\\d{1,2})/readings/(\\b(all|new|old)\\b)", "temperature_$2_in_$1", "$3"));
-        rules.add(new MappingRule("sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match/(\\d+)/.*", "season_$2_$1", "match_$3"));
+        rules.add(new MappingRule("sports/([^/]+)/league/season/(\\d{4}-\\d{4})/match/(\\d+).*", "season_$2_$1", "match_$3"));
 
         MqttKafkaRegexMapper mapper = new MqttKafkaRegexMapper(rules);
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapperTest.java
@@ -61,7 +61,7 @@ public class MqttKafkaRegexMapperTest {
         // Test building/(\\d+)/floor/(\\d+).*
         MappingResult mappingResult = mapper.map("building/14/floor/25");
 
-        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$1_$2",
+        assertThat("building/(\\d+)/floor/(\\d+).* should be mapped to building_$1",
                 mappingResult.kafkaTopic(), is("building_14"));
 
         assertThat("The key for building_$1 should be expanded to room_25",

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapperTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapperTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.mapper;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Unit tests for @{@link MqttKafkaSimpleMapper}.
+ *
+ * @see MqttKafkaSimpleMapper
+ */
+public class MqttKafkaSimpleMapperTest {
+
+    /**
+     * Test for default topic.
+     * If the MQTT topic does not match any of the mapping rules, the default topic is used.
+     * E.g. if the Topic Mapping Rules is empty, the default topic is used by default.
+     */
+    @Test
+    public void testDefaultTopic() {
+        List<MappingRule> rules = new ArrayList<>();
+
+        MqttKafkaSimpleMapper mapper = new MqttKafkaSimpleMapper(rules);
+
+        assertThat("Should use the default topic when no mapping pattern matches.",
+                mapper.map("sensor/temperature").kafkaTopic(), is(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC));
+    }
+
+    /**
+     * Test the mapping of single level topics.
+     */
+    @Test
+    public void testSingleLevel() {
+        List<MappingRule> rules = new ArrayList<>();
+
+        rules.add(new MappingRule("sensors/+/data", "sensor_data", "sensor"));
+        rules.add(new MappingRule("devices/{device}/data", "devices_{device}_data", "device_{device}"));
+        rules.add(new MappingRule("fleet/{fleet}/vehicle/{vehicle}", "fleet_{fleet}", "vehicle_{vehicle}"));
+        rules.add(new MappingRule("building/{building}/floor/{floor}", "building.{building}.floor.{floor}", "floor_{floor}"));
+        rules.add(new MappingRule("term/{number}", "term{number}", null));
+
+        MqttKafkaSimpleMapper mapper = new MqttKafkaSimpleMapper(rules);
+
+        assertThat("Mqtt pattern sensors/+/data should be mapped to sensor_data",
+                mapper.map("sensors/4/data").kafkaTopic(), is("sensor_data"));
+
+        assertThat("The key for sensors/+/data should be sensor",
+                mapper.map("sensors/4/data").kafkaKey(), is("sensor"));
+
+        assertThat("Mqtt pattern devices/{device}/data should be mapped to devices_{device}_data",
+                mapper.map("devices/4/data").kafkaTopic(), is("devices_4_data"));
+
+        assertThat("The key for devices/{device}/data should be device_{device}",
+                mapper.map("devices/4/data").kafkaKey(), is("device_4"));
+
+        assertThat("Mqtt pattern fleet/{fleet}/vehicle/{vehicle} should be mapped to fleet_{fleet}",
+                mapper.map("fleet/4/vehicle/23").kafkaTopic(), is("fleet_4"));
+
+        assertThat("The key for fleet/{fleet}/vehicle/{vehicle} should be vehicle_{vehicle}",
+                mapper.map("fleet/4/vehicle/23").kafkaKey(), is("vehicle_23"));
+
+        assertThat("building/{building}/floor/{floor} should be mapped to building.{building}.floor.{floor}",
+                mapper.map("building/4/floor/23").kafkaTopic(), is("building.4.floor.23"));
+
+        assertThat("The key for building/{building}/floor/{floor} should be floor_{floor}",
+                mapper.map("building/4/floor/23").kafkaKey(), is("floor_23"));
+
+        assertThat("Mqtt pattern term/{number} should be mapped to term{number}",
+                mapper.map("term/4").kafkaTopic(), is("term4"));
+
+        assertThat("The key for term/{number} should be null",
+                mapper.map("term/4").kafkaKey(), is(nullValue()));
+    }
+
+
+    /**
+     * Test the mapping of single level topics.
+     */
+    @Test
+    public void testIllegalPlaceholder() {
+
+        List<MappingRule> rules = new ArrayList<>();
+        rules.add(new MappingRule("fleet/{flee}/vehicle/{vehicle}", "fleet_{fleet}", null));
+        rules.add(new MappingRule("buildings/+/rooms/+/device/+", "buildings_{building}_rooms_{room}_device_{device}", "building"));
+        rules.add(new MappingRule("building/{building}/room/{room}", "building_{building}_room_{room}_{noexistingplaceholder}", null));
+
+        MqttKafkaSimpleMapper mapper = new MqttKafkaSimpleMapper(rules);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> mapper.map("fleet/4/vehicle/23"));
+
+        String expectedMessage = "The placeholder {fleet} was not found assigned any value.";
+        assertThat("The exception message should be: " + expectedMessage,
+                exception.getMessage(), is(expectedMessage));
+
+        Exception otherException = assertThrows(IllegalArgumentException.class, () -> mapper.map("buildings/10/rooms/5/device/3"));
+
+        String otherExpectedMessage = "The placeholder {device} was not found assigned any value.";
+        assertThat("The exception message should be: " + otherExpectedMessage,
+                otherException.getMessage(), is(otherExpectedMessage));
+
+    }
+
+    /**
+     * Test the mapping of multi level topics.
+     */
+    @Test
+    public void testMultiLevel() {
+        List<MappingRule> rules = new ArrayList<>();
+
+        rules.add(new MappingRule("building/{building}/room/{room}/#", "building_{building}_room_{room}", "building"));
+        rules.add(new MappingRule("building/{building}/#", "building_{building}_others", "building_{building}"));
+        rules.add(new MappingRule("building/#", "building_others", null));
+        rules.add(new MappingRule("fleet/{fleet}/vehicle/{vehicle}/#", "fleet_{vehicle}", "vehicle_{vehicle}"));
+        rules.add(new MappingRule("sensor/#", "sensor_data", "sensor"));
+        rules.add(new MappingRule("sport/tennis/{player}/#", "sports_{player}", "player_{player}"));
+        rules.add(new MappingRule("+/recipes/#", "my_recipes", null));
+        rules.add(new MappingRule("{house}/#", "{house}", null));
+
+        MqttKafkaSimpleMapper mapper = new MqttKafkaSimpleMapper(rules);
+
+        // Test fleet/{fleet}/vehicle/{vehicle}/# pattern
+        assertThat("Mqtt topic pattern fleet/{fleet}/vehicle/{vehicle}/# should be mapped to fleet_{vehicle}",
+                mapper.map("fleet/4/vehicle/23/velocity").kafkaTopic(), is("fleet_23"));
+
+        assertThat("The key for fleet/{fleet}/vehicle/{vehicle}/# should be vehicle_{vehicle}",
+                mapper.map("fleet/4/vehicle/23/velocity").kafkaKey(), is("vehicle_23"));
+
+        // Test building/{building}/room/{room}/# pattern
+        assertThat("Mqtt pattern building/{building}/room/{room}/# should be mapped to building_{building}_room_{room}",
+                mapper.map("building/4/room/23/temperature").kafkaTopic(), is("building_4_room_23"));
+
+        assertThat("The key for building/{building}/room/{room}/# should be building}",
+                mapper.map("building/4/room/23/temperature").kafkaKey(), is("building"));
+
+        // Test building/{building}/# pattern
+        assertThat("Mqtt pattern building/{building}/# should be mapped to building_{building}_others",
+                mapper.map("building/405/room").kafkaTopic(), is("building_405_others"));
+
+        assertThat("Mqtt pattern building/# will be mapped to building_101_others because building/{building}/# was defined before building/#",
+                mapper.map("building/101").kafkaTopic(), not("building_others"));
+
+        assertThat("The key for building/{building}/# should be building_{building}",
+                mapper.map("building/405/room").kafkaKey(), is("building_405"));
+
+        // Test building/# pattern
+        assertThat("Mqtt pattern building/# should be mapped to building_others",
+                mapper.map("building").kafkaTopic(), is("building_others"));
+
+        assertThat("The key for building/# should be null",
+                mapper.map("building").kafkaKey(), is(nullValue()));
+
+        // Test sensor/# pattern
+        assertThat("Mqtt pattern sensor/# should be mapped to sensor_data",
+                mapper.map("sensor/temperature").kafkaTopic(), is("sensor_data"));
+
+        assertThat("The key for sensor/# should be sensor",
+                mapper.map("sensor/temperature").kafkaKey(), is("sensor"));
+
+        // Test sport/tennis/{player}/# pattern
+        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
+                mapper.map("sport/tennis/player1").kafkaTopic(), is("sports_player1"));
+
+        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
+                mapper.map("sport/tennis/player100/ranking").kafkaTopic(), is("sports_player100"));
+
+        assertThat("Mqtt pattern sport/tennis/{player}/# should be mapped to sports_{player}",
+                mapper.map("sport/tennis/player123/score/wimbledon").kafkaTopic(), is("sports_player123"));
+
+        assertThat("The key for sport/tennis/{player}/# should be player_{player}",
+                mapper.map("sport/tennis/player123/score/wimbledon").kafkaKey(), is("player_player123"));
+
+        // Test +/recipes/# pattern
+        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
+                mapper.map("italian/recipes/pizza").kafkaTopic(), is("my_recipes"));
+
+        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
+                mapper.map("italian/recipes/pasta").kafkaTopic(), is("my_recipes"));
+
+        assertThat("Mqtt pattern +/recipes/# should be mapped to my_recipes",
+                mapper.map("angolan/recipes/calulu/fish").kafkaTopic(), is("my_recipes"));
+
+        assertThat("The key for +/recipes/# should be null",
+                mapper.map("italian/recipes/pizza").kafkaKey(), nullValue());
+
+        // Test {house}/# pattern
+        assertThat("Mqtt pattern {house}/# should be mapped to {house}",
+                mapper.map("my_house/temperature").kafkaTopic(), is("my_house"));
+
+        assertThat("Mqtt pattern {house}/# should be mapped to {house}",
+                mapper.map("my_house/temperature/room1").kafkaTopic(), is("my_house"));
+
+        assertThat("The key for {house}/# should be null",
+                mapper.map("my_house/temperature").kafkaKey(), nullValue());
+    }
+}

--- a/src/test/resources/mapping-rules-regex.json
+++ b/src/test/resources/mapping-rules-regex.json
@@ -1,0 +1,33 @@
+[
+  {
+    "mqttTopic": "building/([^/]+)/room/([^/]+).*",
+    "kafkaTopic": "building_$1_room_$2",
+    "kafkaKey": "building_$2"
+  },
+  {
+    "mqttTopic": "sensors/([^/]+)/data",
+    "kafkaTopic": "sensor_data"
+  },
+  {
+    "mqttTopic": "devices/([^/]+)/type/([^/]+)/data",
+    "kafkaTopic": "devices_$1_data",
+    "kafkaKey": "devices_$2"
+  },
+  {
+    "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+).*",
+    "kafkaTopic": "fleet_$1_vehicle_$2",
+    "kafkaKey": "vehicle_$2"
+  },
+  {
+    "mqttTopic": "building/[^/]+.*",
+    "kafkaTopic": "building_$1_others"
+  },
+  {
+    "mqttTopic": "sensors.*",
+    "kafkaTopic": "sensor_others"
+  },
+  {
+    "mqttTopic": "building.*",
+    "kafkaTopic": "building_others"
+  }
+]

--- a/src/test/resources/mapping-rules-regex.json
+++ b/src/test/resources/mapping-rules-regex.json
@@ -19,7 +19,7 @@
     "kafkaKey": "vehicle_$2"
   },
   {
-    "mqttTopic": "building/([^/]+)/.*",
+    "mqttTopic": "building/([^/]+)/(?:\\/.*)?$",
     "kafkaTopic": "building_$1_others"
   },
   {

--- a/src/test/resources/mapping-rules-regex.json
+++ b/src/test/resources/mapping-rules-regex.json
@@ -1,7 +1,7 @@
 [
   {
-    "mqttTopic": "building/([^/]+)/room/([^/]+).*",
-    "kafkaTopic": "building_$1_room_$2",
+    "mqttTopic": "building/([^/]+)/room/([^/]+)/.*",
+    "kafkaTopic": "building_$1",
     "kafkaKey": "building_$2"
   },
   {
@@ -14,12 +14,12 @@
     "kafkaKey": "devices_$2"
   },
   {
-    "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+).*",
-    "kafkaTopic": "fleet_$1_vehicle_$2",
+    "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+)/.*",
+    "kafkaTopic": "fleet_$1",
     "kafkaKey": "vehicle_$2"
   },
   {
-    "mqttTopic": "building/[^/]+.*",
+    "mqttTopic": "building/([^/]+)/.*",
     "kafkaTopic": "building_$1_others"
   },
   {
@@ -27,7 +27,7 @@
     "kafkaTopic": "sensor_others"
   },
   {
-    "mqttTopic": "building.*",
+    "mqttTopic": "building/.*",
     "kafkaTopic": "building_others"
   }
 ]

--- a/src/test/resources/mapping-rules.json
+++ b/src/test/resources/mapping-rules.json
@@ -1,33 +1,33 @@
 [
   {
-    "mqttTopic": "building/([^/]+)/room/([^/]+).*",
-    "kafkaTopic": "building_$1_room_$2",
-    "kafkaKey": "building_$2"
+    "mqttTopic": "building/{building}/room/{room}/#",
+    "kafkaTopic": "building_{building}",
+    "kafkaKey": "room_{room}"
   },
   {
-    "mqttTopic": "sensors/([^/]+)/data",
+    "mqttTopic": "sensors/+/data",
     "kafkaTopic": "sensor_data"
   },
   {
-    "mqttTopic": "devices/([^/]+)/type/([^/]+)/data",
-    "kafkaTopic": "devices_$1_data",
-    "kafkaKey": "devices_$2"
+    "mqttTopic": "devices/{device}/type/{type}/data",
+    "kafkaTopic": "devices_{device}_data",
+    "kafkaKey": "devices_{type}"
   },
   {
-    "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+).*",
-    "kafkaTopic": "fleet_$1_vehicle_$2",
-    "kafkaKey": "vehicle_$2"
+    "mqttTopic": "fleet/{fleet}/vehicle/{vehicle}/#",
+    "kafkaTopic": "fleet_{vehicle}",
+    "kafkaKey": "vehicle_{vehicle}"
   },
   {
-    "mqttTopic": "building/[^/]+.*",
-    "kafkaTopic": "building_$1_others"
+    "mqttTopic": "building/{building}/#",
+    "kafkaTopic": "building_{building}_others"
   },
   {
-    "mqttTopic": "sensors.*",
+    "mqttTopic": "sensors/#",
     "kafkaTopic": "sensor_others"
   },
   {
-    "mqttTopic": "building.*",
+    "mqttTopic": "building/#",
     "kafkaTopic": "building_others"
   }
 ]

--- a/src/test/resources/mapping-rules.json
+++ b/src/test/resources/mapping-rules.json
@@ -6,18 +6,17 @@
   },
   {
     "mqttTopic": "sensors/([^/]+)/data",
-    "kafkaTopic": "sensor_data",
-    "kafkaKey": "sensor_$1"
+    "kafkaTopic": "sensor_data"
   },
   {
-    "mqttTopic": "devices/([^/]+)/data",
+    "mqttTopic": "devices/([^/]+)/type/([^/]+)/data",
     "kafkaTopic": "devices_$1_data",
-    "kafkaKey": "devices_$1"
+    "kafkaKey": "devices_$2"
   },
   {
     "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+).*",
     "kafkaTopic": "fleet_$1_vehicle_$2",
-    "kafkaKey": "fleet_$2"
+    "kafkaKey": "vehicle_$2"
   },
   {
     "mqttTopic": "building/[^/]+.*",
@@ -25,12 +24,10 @@
   },
   {
     "mqttTopic": "sensors.*",
-    "kafkaTopic": "sensor_others",
-    "kafkaKey": "sensor"
+    "kafkaTopic": "sensor_others"
   },
   {
     "mqttTopic": "building.*",
-    "kafkaTopic": "building_others",
-    "kafkaKey": "building"
+    "kafkaTopic": "building_others"
   }
 ]

--- a/src/test/resources/mapping-rules.json
+++ b/src/test/resources/mapping-rules.json
@@ -1,30 +1,36 @@
 [
   {
-    "mqttTopic": "building/{building}/room/{room}/#",
-    "kafkaTopic": "building_{building}_room_{room}"
+    "mqttTopic": "building/([^/]+)/room/([^/]+).*",
+    "kafkaTopic": "building_$1_room_$2",
+    "kafkaKey": "building_$2"
   },
   {
-    "mqttTopic": "sensors/+/data",
-    "kafkaTopic": "sensor_data"
+    "mqttTopic": "sensors/([^/]+)/data",
+    "kafkaTopic": "sensor_data",
+    "kafkaKey": "sensor_$1"
   },
   {
-    "mqttTopic": "devices/{device}/data",
-    "kafkaTopic": "devices_{device}_data"
+    "mqttTopic": "devices/([^/]+)/data",
+    "kafkaTopic": "devices_$1_data",
+    "kafkaKey": "devices_$1"
   },
   {
-    "mqttTopic": "fleet/{fleet}/vehicle/{vehicle}/#",
-    "kafkaTopic": "fleet_{vehicle}"
+    "mqttTopic": "fleet/([^/]+)/vehicle/([^/]+).*",
+    "kafkaTopic": "fleet_$1_vehicle_$2",
+    "kafkaKey": "fleet_$2"
   },
   {
-    "mqttTopic": "building/{building}/#",
-    "kafkaTopic": "building_{building}_others"
+    "mqttTopic": "building/[^/]+.*",
+    "kafkaTopic": "building_$1_others"
   },
   {
-    "mqttTopic": "sensors/#",
-    "kafkaTopic": "sensor_others"
+    "mqttTopic": "sensors.*",
+    "kafkaTopic": "sensor_others",
+    "kafkaKey": "sensor"
   },
   {
-    "mqttTopic": "building/#",
-    "kafkaTopic": "building_others"
+    "mqttTopic": "building.*",
+    "kafkaTopic": "building_others",
+    "kafkaKey": "building"
   }
 ]


### PR DESCRIPTION
This PR includes:
- Added `kafkaKey` in the Topic Mapping Rules (this will fix #20).
- New way to define MQTT topic pattern: Now users can use regex as MQTT patterns, and gives the user more possibility to define rules.
- Placeholders are no longer defined as `{placeholder}`: Now we are using positional placeholders like $1, which means, get the value of the first capturing group in the MQTT pattern.
- The MqttKafkaMapper.map(String) does not return a String: Now the result of the mapping consists of a Kafka Topic and a Kafka record key, and they are wrapped in an object of a class called `MappingResult`.
-Tests for the new Mapper.
- Updated docs.