### PR TITLE
Make the --config-file mandatory and fix config related test

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
@@ -72,6 +72,7 @@ public class Main {
         Option optionConfigFile = Option.builder()
                 .longOpt(Main.CONFIG_FILE_OPTION)
                 .hasArg(true)
+                .required()
                 .desc("The path to the configuration file")
                 .build();
         options.addOption(optionConfigFile);

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/core/ConfigRetrieverTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/core/ConfigRetrieverTest.java
@@ -47,7 +47,7 @@ public class ConfigRetrieverTest {
         assertThat("There should be 1 related kafka config parameters",
                 bridgeConfig.getKafkaConfig().getConfig().size(), is(1));
         assertThat("The address of the kafka bootstrap server should be 'localhost:9092'",
-                bridgeConfig.getKafkaConfig().getConfig().get(KafkaConfig.BOOTSTRAP_SERVERS_CONFIG), is("localhost:9092"));
+                bridgeConfig.getKafkaConfig().getConfig().get("bootstrap.servers"), is("localhost:9092"));
     }
 
     /**


### PR DESCRIPTION
This trivial PR makes the configuration file command line parameter as mandatory as we don't want user to run the bridge with a built in configuration y default which could not work for them. Let's follow the same Strimzi HTTP bridge approach.
This also fix a config related test which is anyway not related to the above change.