### PR TITLE
Added initial Makefile(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+include ./Makefile.os
+include ./Makefile.maven
+
+PROJECT_NAME ?= mqtt-bridge
+
+.PHONY: all
+all: java_verify
+
+.PHONY: clean
+clean: java_clean

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -1,0 +1,27 @@
+# Makefile.maven contains the shared tasks for building Java applications. This file is
+# included into the Makefile files which contain some Java sources which should be build
+
+.PHONY: java_compile
+java_compile:
+	echo "Building JAR file ..."
+	mvn $(MVN_ARGS) compile
+
+.PHONY: java_verify
+java_verify:
+	echo "Building JAR file ..."
+	mvn $(MVN_ARGS) verify
+
+.PHONY: java_package
+java_package:
+	echo "Packaging project ..."
+	mvn $(MVN_ARGS) package
+
+.PHONY: java_install
+java_install:
+	echo "Installing JAR files ..."
+	mvn $(MVN_ARGS) install
+
+.PHONY: java_clean
+java_clean:
+	echo "Cleaning Maven build ..."
+	mvn clean

--- a/Makefile.os
+++ b/Makefile.os
@@ -1,0 +1,12 @@
+FIND = find
+SED = sed
+GREP = grep
+CP = cp
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	FIND = gfind
+	SED = gsed
+	GREP = ggrep
+	CP = gcp
+endif


### PR DESCRIPTION
This PR adds Makefile(s) just for running a Java build. No Docker included, no spotbugs and so on.
We'll add more as they come.
This is an initial step to use them in the upcoming Azure pipeline for the project mostly to build and run tests.