### PR TITLE
Added Azure pipeline for Java build and tests

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -1,0 +1,17 @@
+# Triggers
+trigger:
+  branches:
+    include:
+      - 'main'
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'
+
+# Stages
+stages:
+  - stage: java_build
+    displayName: Java build
+    jobs:
+      - template: 'templates/jobs/build_java.yaml'

--- a/.azure/scripts/java-build.sh
+++ b/.azure/scripts/java-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Build reason: ${BUILD_REASON}"
+echo "Source branch: ${BRANCH}"
+
+# Build with Maven
+make java_verify

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -1,0 +1,32 @@
+jobs:
+  - job: 'build_and_test_java'
+    displayName: 'Build & Test'
+    # Strategy for the job
+    strategy:
+      matrix:
+        'java-17':
+          image: 'Ubuntu-22.04'
+          jdk_version: '17'
+          main_build: 'false'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: $(image)
+    # Variables
+    variables:
+      MVN_CACHE_FOLDER: $(HOME)/.m2/repository
+      MVN_ARGS: '-e -V -B'
+    # Pipeline steps
+    steps:
+      # Get cached Maven repository
+      - template: "../steps/maven_cache.yaml"
+      - template: '../steps/setup_java.yaml'
+        parameters:
+          JDK_VERSION: $(jdk_version)
+      - bash: ".azure/scripts/java-build.sh"
+        displayName: "Build & Test Java"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          MVN_ARGS: "-e -V -B"

--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      restoreKeys: |
+        maven-cache | $(System.JobName)
+        maven-cache
+      path: $(HOME)/.m2/repository
+    displayName: Maven cache

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,0 +1,12 @@
+# Step to setup JAVA on the agent
+parameters:
+  - name: JDK_VERSION
+    default: '17'
+
+steps:
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: $(JDK_VERSION)
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+    displayName: 'Configure Java'


### PR DESCRIPTION
This PR adds an initial configuration for an Azure pipeline just to build Java and run tests.
More stuff will be added when it comes (i.e. spotbugs, containers, ...).