### PR TITLE
Bumped Jackson to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <log4j.version>2.17.2</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <junit.version>4.13.2</junit.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <kafka.version>3.5.0</kafka.version>
         <mockito.version>4.11.0</mockito.version>


### PR DESCRIPTION
Trivial PR to bump Jackson deps to 2.15.2 to avoid potential vulnerabilities and align with latest update in the Strimzi operator https://github.com/strimzi/strimzi-kafka-operator/pull/8856 and HTTP bridge https://github.com/strimzi/strimzi-kafka-bridge/pull/822