### PR TITLE
Moved classes out of utils

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
@@ -10,7 +10,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.strimzi.kafka.bridge.mqtt.config.BridgeConfig;
 import io.strimzi.kafka.bridge.mqtt.config.ConfigRetriever;
 import io.strimzi.kafka.bridge.mqtt.core.MqttServer;
-import io.strimzi.kafka.bridge.mqtt.utils.MappingRulesLoader;
+import io.strimzi.kafka.bridge.mqtt.mapper.MappingRulesLoader;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -19,7 +19,7 @@ import io.strimzi.kafka.bridge.mqtt.mapper.MqttKafkaMapper;
 import io.strimzi.kafka.bridge.mqtt.mapper.MqttKafkaRegexMapper;
 import io.strimzi.kafka.bridge.mqtt.mapper.MappingRule;
 import io.strimzi.kafka.bridge.mqtt.mapper.MappingResult;
-import io.strimzi.kafka.bridge.mqtt.utils.MappingRulesLoader;
+import io.strimzi.kafka.bridge.mqtt.mapper.MappingRulesLoader;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/kafka/KafkaBridgeProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/kafka/KafkaBridgeProducer.java
@@ -5,7 +5,6 @@
 package io.strimzi.kafka.bridge.mqtt.kafka;
 
 import io.strimzi.kafka.bridge.mqtt.config.KafkaConfig;
-import io.strimzi.kafka.bridge.mqtt.utils.KafkaProducerAckLevel;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/kafka/KafkaProducerAckLevel.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/kafka/KafkaProducerAckLevel.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.utils;
+package io.strimzi.kafka.bridge.mqtt.kafka;
 
 /**
  * Represents the Kafka producer ack level

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRulesLoader.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRulesLoader.java
@@ -2,10 +2,9 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.utils;
+package io.strimzi.kafka.bridge.mqtt.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.strimzi.kafka.bridge.mqtt.mapper.MappingRule;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRulesLoaderTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/mapper/MappingRulesLoaderTest.java
@@ -2,11 +2,9 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.kafka.bridge.mqtt.core.utils;
+package io.strimzi.kafka.bridge.mqtt.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.strimzi.kafka.bridge.mqtt.mapper.MappingRule;
-import io.strimzi.kafka.bridge.mqtt.utils.MappingRulesLoader;
 import org.junit.Test;
 
 import java.nio.file.Path;


### PR DESCRIPTION
This PR moves some classes out of the `utils` package because they can't be considered "just" utils.
The `KafkaProducerAckLevel` was moved into `kafka` package because it's actual part of the Kafka producer logic.
The `MappingRulesLoader` was moved into `mapper` package bacause it's the main piece loading the mapping rules.