### PR TITLE
Added Surefire and Failsafe plugins for running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <hamcrest.version>2.2</hamcrest.version>
         <test-container.version>0.104.0</test-container.version>
         <eclipse-paho.version>1.2.5</eclipse-paho.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
     </properties>
 
     <dependencies>
@@ -113,4 +115,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
It seems that the addition of the test-container dependency (bringing an implicit failsafe plugin configuration) breaks tests which don't run anymore.
This PR adds usage of Failsafe plugin (for integration tests) and Surefire pluging (for unit tests) explicitely fixing this issue.