### PR TITLE
Add the published MQTT topic in the produced Kafka record header

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -22,6 +22,9 @@ import io.strimzi.kafka.bridge.mqtt.mapper.MappingResult;
 import io.strimzi.kafka.bridge.mqtt.mapper.MappingRulesLoader;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,9 +151,11 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
         logger.info("MQTT topic {} mapped to Kafka Topic {} with Key {}", mqttTopic, mappingResult.kafkaTopic(), mappingResult.kafkaKey());
 
         byte[] data = payloadToBytes(publishMessage);
+        Headers headers = new RecordHeaders();
+        headers.add(new RecordHeader("mqtt-topic", mqttTopic.getBytes()));
         // build the Kafka record
-        ProducerRecord<String, byte[]> record = new ProducerRecord<>(mappingResult.kafkaTopic(), mappingResult.kafkaKey(),
-                data);
+        ProducerRecord<String, byte[]> record = new ProducerRecord<>(mappingResult.kafkaTopic(), null, mappingResult.kafkaKey(),
+                data, headers);
 
         // send the record to the Kafka topic
         switch (qos) {

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
@@ -203,6 +203,8 @@ public class MqttBridgetIT {
                     record.value(), is("Hello world"));
             assertThat("The topic should be " + KAFKA_TOPIC,
                     record.topic(), is(KAFKA_TOPIC));
+            assertThat("The record headers should contain the MQTT topic " + mqttTopic,
+                    record.headers().lastHeader("mqtt-topic").value(), is(mqttTopic.getBytes()));
 
             // Disconnect the client
             client.disconnect();


### PR DESCRIPTION
This trivial PR adds the published MQTT topic to the produced Kafka record header so the Kafka consumer can get where the message was published.