### PR TITLE
Refactor MQTT host and port properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ A valid configuration file should look like this:
     # Bridge configuration
     bridge.id=my-bridge
     # MQTT configuration
-    mqtt.server.host=localhost
-    mqtt.server.port=1883
+    mqtt.host=localhost
+    mqtt.port=1883
     # Kafka configuration
     kafka.bootstrap.servers=localhost:9092
    ```
@@ -177,8 +177,8 @@ The following table describes the configuration properties defined above.
 | Setting                 | Description                        | Default        |
 |-------------------------|------------------------------------|----------------|
 | bridge.id               | ID of the bridge                   | my-bridge      |
-| mqtt.server.host        | Host address of the MQTT server    | localhost      |
-| mqtt.server.port        | Port number of the MQTT server     | 1883           |
+| mqtt.host               | Host address of the MQTT server    | localhost      |
+| mqtt.port               | Port number of the MQTT server     | 1883           |
 | kafka.bootstrap.servers | Bootstrap servers for Apache Kafka | localhost:9092 |
 
 Other than the above properties, the user can also configure the bridge using environment variables.

--- a/config/application.properties
+++ b/config/application.properties
@@ -2,8 +2,8 @@
 bridge.id=my-bridge
 
 #MQTT server common
-mqtt.server.host=localhost
-mqtt.server.port=1883
+mqtt.host=localhost
+mqtt.port=1883
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092

--- a/install/020-ConfigMap.yaml
+++ b/install/020-ConfigMap.yaml
@@ -10,8 +10,8 @@ data:
     bridge.id=my-bridge
 
     #MQTT server common
-    mqtt.server.host=0.0.0.0
-    mqtt.server.port=1883
+    mqtt.host=0.0.0.0
+    mqtt.port=1883
     #Apache Kafka common
     kafka.bootstrap.servers=<kafka-bootstrap-servers>
   topic-mapping-rules.json: '[]'

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/config/MqttConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/config/MqttConfig.java
@@ -16,9 +16,9 @@ public class MqttConfig extends AbstractConfig {
     // Prefix for all the specific configuration parameters for MQTT in the properties file
     public static final String MQTT_CONFIG_PREFIX = "mqtt.";
 
-    public static final String MQTT_HOST = MQTT_CONFIG_PREFIX + "server.host";
+    public static final String MQTT_HOST = MQTT_CONFIG_PREFIX + "host";
 
-    public static final String MQTT_PORT = MQTT_CONFIG_PREFIX + "server.port";
+    public static final String MQTT_PORT = MQTT_CONFIG_PREFIX + "port";
 
     public static final String DEFAULT_MQTT_HOST = "0.0.0.0";
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigTest.java
@@ -27,8 +27,8 @@ public class ConfigTest {
         map.put("bridge.id", "my-bridge");
         map.put("kafka.bootstrap.servers", "localhost:9092");
         map.put("kafka.producer.acks", "1");
-        map.put("mqtt.server.host", "0.0.0.0");
-        map.put("mqtt.server.port", "1883");
+        map.put("mqtt.host", "0.0.0.0");
+        map.put("mqtt.port", "1883");
 
         BridgeConfig bridgeConfig = BridgeConfig.fromMap(map);
         assertThat(bridgeConfig.getBridgeID(), is("my-bridge"));

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,8 +2,8 @@
 bridge.id=my-bridge
 
 #MQTT server common
-mqtt.server.host=localhost
-mqtt.server.port=1883
+mqtt.host=localhost
+mqtt.port=1883
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092


### PR DESCRIPTION
This PR removes the `server` prefix for MQTT host and port to stick with the same pattern we have with the current Strimzi HTTP bridge.
It's anyway clear what's the purpose of host and port, it could be server only because the bridge doesn't have any client part.