### PR TITLE
Added spotbugs

### DIFF
--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven.assembly.version>3.4.2</maven.assembly.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
+        <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
     </properties>
 
     <dependencies>
@@ -84,6 +86,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Testing -->
         <dependency>
@@ -167,6 +175,30 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${maven.spotbugs.version}</version>
+                <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>${spotbugs.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <effort>Max</effort>
+                    <!-- Reports all bugs (other values are medium and max) -->
+                    <threshold>Low</threshold>
+                    <!-- Produces XML report -->
+                    <xmlOutput>true</xmlOutput>
+                    <!-- Configures the directory in which the XML report is created -->
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs</spotbugsXmlOutputDirectory>
+                    <!-- Configures the file for excluding warnings -->
+                    <excludeFilterFile>${project.basedir}/.spotbugs/spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
@@ -15,10 +15,12 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -64,7 +66,7 @@ public class Main {
             // start the MQTT server
             mqttServer.start();
             latch.await();
-        } catch (Exception e) {
+        } catch (InterruptedException | ParseException | IOException e) {
             logger.error("Error starting the MQTT server: ", e);
             System.exit(1);
         }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaMapper.java
@@ -33,7 +33,6 @@ public abstract class MqttKafkaMapper {
     protected MqttKafkaMapper(List<MappingRule> rules, Pattern placeholderPattern) {
         this.rules = rules;
         this.placeholderPattern = placeholderPattern;
-        this.buildOrCompilePatterns();
     }
 
     /**
@@ -43,9 +42,4 @@ public abstract class MqttKafkaMapper {
      * @return a MappingResult object containing the mapped Kafka topic and Kafka key.
      */
     public abstract MappingResult map(String mqttTopic);
-
-    /**
-     * Helper method for Building the regex expressions for the mapping rules.
-     */
-    protected abstract void buildOrCompilePatterns();
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -22,6 +22,7 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
      */
     public MqttKafkaRegexMapper(List<MappingRule> rules) {
         super(rules, Pattern.compile(MQTT_TOPIC_DOLLAR_PLACEHOLDER_REGEX));
+        this.buildOrCompilePatterns();
     }
 
     @Override
@@ -52,8 +53,10 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
         return new MappingResult(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC, null);
     }
 
-    @Override
-    protected void buildOrCompilePatterns() {
+    /**
+     * Helper method for Building the regex expressions for the mapping rules.
+     */
+    private void buildOrCompilePatterns() {
         this.rules.forEach(rule-> this.patterns.add(Pattern.compile(rule.getMqttTopicPattern())));
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -41,6 +41,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
      */
     public MqttKafkaSimpleMapper(List<MappingRule> rules) {
         super(rules, Pattern.compile(MQTT_TOPIC_PLACEHOLDER_REGEX));
+        this.buildOrCompilePatterns();
     }
 
     @Override
@@ -96,8 +97,10 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
         return new MappingResult(MqttKafkaMapper.DEFAULT_KAFKA_TOPIC, null);
     }
 
-    @Override
-    protected void buildOrCompilePatterns() {
+    /**
+     * Helper method for Building the regex expressions for the mapping rules.
+     */
+    private void buildOrCompilePatterns() {
 
         // convert the mqtt patterns to a valid regex expression.
         // the mqtt pattern can contain placeholders like {something}, + and #.


### PR DESCRIPTION
This PR adds spotbugs and also makes some changes on the Java code.
These changes are related to the following warnings raised by spotbugs:

```shell
[INFO] Total bugs: 6
[ERROR] Low: Exception is caught when Exception is not thrown in io.strimzi.kafka.bridge.mqtt.Main.main(String[]) [io.strimzi.kafka.bridge.mqtt.Main] At Main.java:[line 67] REC_CATCH_EXCEPTION
[ERROR] Low: Unchecked/unconfirmed cast from io.netty.handler.codec.mqtt.MqttMessage to io.netty.handler.codec.mqtt.MqttConnectMessage in io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler.channelRead0(ChannelHandlerContext, MqttMessage) [io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler] At MqttServerHandler.java:[line 86] BC_UNCONFIRMED_CAST
[ERROR] Low: Unchecked/unconfirmed cast from io.netty.handler.codec.mqtt.MqttMessage to io.netty.handler.codec.mqtt.MqttPublishMessage in io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler.channelRead0(ChannelHandlerContext, MqttMessage) [io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler] At MqttServerHandler.java:[line 88] BC_UNCONFIRMED_CAST
[ERROR] High: Found reliance on default encoding in io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler.handlePublishMessage(ChannelHandlerContext, MqttPublishMessage): String.getBytes() [io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler] At MqttServerHandler.java:[line 155] DM_DEFAULT_ENCODING
[ERROR] Medium: Switch statement found in io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler.handlePublishMessage(ChannelHandlerContext, MqttPublishMessage) where default case is missing [io.strimzi.kafka.bridge.mqtt.core.MqttServerHandler] At MqttServerHandler.java:[lines 161-179] SF_SWITCH_NO_DEFAULT
[ERROR] Low: Overridable method buildOrCompilePatterns is called from constructor new io.strimzi.kafka.bridge.mqtt.mapper.MqttKafkaMapper(List, Pattern). [io.strimzi.kafka.bridge.mqtt.mapper.MqttKafkaMapper] At MqttKafkaMapper.java:[line 36] MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR
```