### PR TITLE
Added checkstyle

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<module name = "Checker">
+
+    <property name="localeLanguage" value="en"/>
+
+    <module name="FileTabCharacter"/>
+
+    <!-- header -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="${checkstyle.header.file}"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <module name="SuppressWarningsFilter" />
+
+    <module name="TreeWalker">
+
+        <!-- code cleanup -->
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true" />
+        </module>
+        <module name="RedundantImport"/>
+        <module name="IllegalImport" />
+        <module name="EqualsHashCode"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="OneStatementPerLine"/>
+        <module name="UnnecessaryParentheses" />
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- style -->
+        <module name="DefaultComesLast"/>
+        <module name="EmptyStatement"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="UpperEll"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="EmptyStatement"/>
+        <module name="ConstantName">
+            <property name="format" value="(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)"/>
+        </module>
+        <module name="LocalVariableName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="MemberName"/>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+
+        <!-- dependencies -->
+        <!--<module name="ImportControl">
+            <property name="file" value="${importControlFile}"/>
+        </module>-->
+
+        <!-- whitespace -->
+        <module name="GenericWhitespace"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="WhitespaceAfter" />
+        <module name="NoWhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+        </module>
+        <module name="Indentation"/>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+
+        <!-- locale-sensitive methods should specify locale -->
+        <module name="Regexp">
+            <property name="format" value="\.to(Lower|Upper)Case\(\)"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <!-- code quality -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber">
+            <!-- default is 8 -->
+        </module>
+        <module name="ClassDataAbstractionCoupling">
+            <!-- default is 7 -->
+        </module>
+        <module name="BooleanExpressionComplexity">
+            <!-- default is 3 -->
+        </module>
+
+        <module name="ClassFanOutComplexity">
+            <!-- default is 20 -->
+        </module>
+        <module name="CyclomaticComplexity">
+            <!-- default is 10-->
+        </module>
+        <module name="JavaNCSS">
+            <!-- default is 50 -->
+        </module>
+        <module name="NPathComplexity">
+            <!-- default is 200 -->
+        </module>
+
+        <module name="IllegalToken">
+            <property name="tokens" value="LITERAL_ASSERT"/>
+        </module>
+
+        <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
+        <module name="SuppressWarningsHolder" />
+    </module>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${checkstyle.suppressions.file}"/>
+    </module>
+
+    <!-- Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
+    <module name="SuppressWarningsFilter" />
+</module>

--- a/.checkstyle/java.header
+++ b/.checkstyle/java.header
@@ -1,0 +1,4 @@
+^/\*
+^ \* Copyright Strimzi authors.
+^ \* License: Apache License 2\.0 \(see the file LICENSE or http://apache\.org/licenses/LICENSE-2\.0\.html\)\.
+^ \*/

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- Suppressing unnecessary parentheses as in some cases it is better to use them for better code readilibity-->
+    <suppress checks="UnnecessaryParentheses"
+              files="io[/\\]strimzi[/\\].*"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
         <maven.assembly.version>3.4.2</maven.assembly.version>
         <spotbugs.version>4.7.3</spotbugs.version>
         <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
+        <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
+        <checkstyle.version>10.12.2</checkstyle.version>
     </properties>
 
     <dependencies>
@@ -199,6 +201,36 @@
                     <!-- Configures the file for excluding warnings -->
                     <excludeFilterFile>${project.basedir}/.spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven.checkstyle.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>.checkstyle/checkstyle.xml</configLocation>
+                            <headerLocation>.checkstyle/java.header</headerLocation>
+                            <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
@@ -25,12 +25,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 public class Main {
-    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+    private static final Logger log = LoggerFactory.getLogger(Main.class);
     private static final String CONFIG_FILE_OPTION = "config-file";
     private static final String MAPPING_RULES_FILE_OPTION = "mapping-rules";
 
     public static void main(String[] args) {
-        logger.info("Strimzi MQTT Bridge {} is starting", Main.class.getPackage().getImplementationVersion());
+        log.info("Strimzi MQTT Bridge {} is starting", Main.class.getPackage().getImplementationVersion());
         try {
             //prepare the command line options
             CommandLine cmd = new DefaultParser().parse(generateCommandLineOptions(), args);
@@ -41,7 +41,7 @@ public class Main {
 
             Map<String, ?> configRetriever = configFilePath != null ? ConfigRetriever.getConfig(configFilePath) : ConfigRetriever.getConfigFromEnv();
             BridgeConfig bridgeConfig = BridgeConfig.fromMap((Map<String, Object>) configRetriever);
-            logger.info("Bridge configuration {}", bridgeConfig);
+            log.info("Bridge configuration {}", bridgeConfig);
 
             //set the mapping rules file path
             MappingRulesLoader.getInstance().init(mappingRulesFile);
@@ -57,7 +57,7 @@ public class Main {
                 try {
                     mqttServer.stop();
                 } catch (Exception e) {
-                    logger.error("Error stopping the MQTT server: ", e);
+                    log.error("Error stopping the MQTT server: ", e);
                 } finally {
                     latch.countDown();
                 }
@@ -67,7 +67,7 @@ public class Main {
             mqttServer.start();
             latch.await();
         } catch (InterruptedException | ParseException | IOException e) {
-            logger.error("Error starting the MQTT server: ", e);
+            log.error("Error starting the MQTT server: ", e);
             System.exit(1);
         }
         System.exit(0);

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/config/MqttConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/config/MqttConfig.java
@@ -60,7 +60,7 @@ public class MqttConfig extends AbstractConfig {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return "MqttConfig(" +
                 "config=" + config +
                 ")";

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServer.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * Represents the MqttServer component.
  */
 public class MqttServer {
-    private static final Logger logger = LoggerFactory.getLogger(MqttServer.class);
+    private static final Logger log = LoggerFactory.getLogger(MqttServer.class);
     private final EventLoopGroup masterGroup;
     private final EventLoopGroup workerGroup;
     private final ServerBootstrap serverBootstrap;
@@ -65,15 +65,15 @@ public class MqttServer {
      * Stop the server.
      */
     public void stop() throws InterruptedException {
-        logger.info("Shutting down Netty server...");
+        log.info("Shutting down Netty server...");
         this.channelFuture.channel().close().sync();
         this.channelFuture.channel().closeFuture().sync();
         this.masterGroup.shutdownGracefully().sync();
         this.workerGroup.shutdownGracefully().sync();
-        logger.info("Netty server shut down");
+        log.info("Netty server shut down");
 
-        logger.info("Closing Kafka producers...");
+        log.info("Closing Kafka producers...");
         this.kafkaBridgeProducer.close();
-        logger.info("Kafka producers closed");
+        log.info("Kafka producers closed");
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -42,9 +42,10 @@ import static io.netty.channel.ChannelHandler.Sharable;
  *
  * @see io.netty.channel.SimpleChannelInboundHandler
  */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @Sharable
 public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> {
-    private static final Logger logger = LoggerFactory.getLogger(MqttServerHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(MqttServerHandler.class);
     private final KafkaBridgeProducer kafkaBridgeProducer;
     private MqttKafkaMapper mqttKafkaMapper;
 
@@ -59,7 +60,7 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
             List<MappingRule> rules = mappingRulesLoader.loadRules();
             this.mqttKafkaMapper = new MqttKafkaRegexMapper(rules);
         } catch (IOException e) {
-            logger.error("Error reading mapping file: ", e);
+            log.error("Error reading mapping file: ", e);
         }
         this.kafkaBridgeProducer = kafkaBridgeProducer;
     }
@@ -75,23 +76,23 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        logger.info("Client  {} is trying to connect", ctx.channel().remoteAddress());
+        log.info("Client  {} is trying to connect", ctx.channel().remoteAddress());
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, MqttMessage msg) {
         try {
             MqttMessageType messageType = msg.fixedHeader().messageType();
-            logger.debug("Got {} message type", messageType.name());
+            log.debug("Got {} message type", messageType.name());
             if (msg instanceof MqttConnectMessage) {
                 handleConnectMessage(ctx, (MqttConnectMessage) msg);
             } else if (msg instanceof MqttPublishMessage) {
                 handlePublishMessage(ctx, (MqttPublishMessage) msg);
             } else {
-                logger.warn("Message type {} not handled", messageType.name());
+                log.warn("Message type {} not handled", messageType.name());
             }
         } catch (Exception e) {
-            logger.error("Error reading Channel: ", e);
+            log.error("Error reading Channel: ", e);
             ctx.close();
         }
     }
@@ -114,7 +115,7 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
                 .returnCode(MqttConnectReturnCode.CONNECTION_ACCEPTED)
                 .build();
 
-        logger.info("Client [{}] connected from {}", connectMessage.payload().clientIdentifier(), ctx.channel().remoteAddress());
+        log.info("Client [{}] connected from {}", connectMessage.payload().clientIdentifier(), ctx.channel().remoteAddress());
         ctx.writeAndFlush(connAckMessage);
     }
 
@@ -149,7 +150,7 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
         MappingResult mappingResult = mqttKafkaMapper.map(mqttTopic);
 
         // log the topic mapping
-        logger.info("MQTT topic {} mapped to Kafka Topic {} with Key {}", mqttTopic, mappingResult.kafkaTopic(), mappingResult.kafkaKey());
+        log.info("MQTT topic {} mapped to Kafka Topic {} with Key {}", mqttTopic, mappingResult.kafkaTopic(), mappingResult.kafkaKey());
 
         byte[] data = payloadToBytes(publishMessage);
         Headers headers = new RecordHeaders();
@@ -162,22 +163,22 @@ public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> 
         switch (qos) {
             case AT_MOST_ONCE -> {
                 kafkaBridgeProducer.sendNoAck(record);
-                logger.info("Message sent to Kafka on topic {}", record.topic());
+                log.info("Message sent to Kafka on topic {}", record.topic());
             }
             case AT_LEAST_ONCE -> {
                 CompletionStage<RecordMetadata> result = kafkaBridgeProducer.send(record);
                 // wait for the result of the send operation
                 result.whenComplete((metadata, error) -> {
                     if (error != null) {
-                        logger.error("Error sending message to Kafka: ", error);
+                        log.error("Error sending message to Kafka: ", error);
                     } else {
-                        logger.info("Message sent to Kafka on topic {} with offset {}", metadata.topic(), metadata.offset());
+                        log.info("Message sent to Kafka on topic {} with offset {}", metadata.topic(), metadata.offset());
                         // send PUBACK message to the client
                         sendPubAckMessage(ctx, publishMessage.variableHeader().packetId());
                     }
                 });
             }
-            case EXACTLY_ONCE -> logger.warn("QoS level EXACTLY_ONCE is not supported");
+            case EXACTLY_ONCE -> log.warn("QoS level EXACTLY_ONCE is not supported");
             default -> throw new IllegalArgumentException("QoS level " + qos + "not supported");
         }
     }

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java
@@ -57,7 +57,7 @@ public class MqttKafkaRegexMapper extends MqttKafkaMapper {
      * Helper method for Building the regex expressions for the mapping rules.
      */
     private void buildOrCompilePatterns() {
-        this.rules.forEach(rule-> this.patterns.add(Pattern.compile(rule.getMqttTopicPattern())));
+        this.rules.forEach(rule -> this.patterns.add(Pattern.compile(rule.getMqttTopicPattern())));
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java
@@ -44,6 +44,7 @@ public class MqttKafkaSimpleMapper extends MqttKafkaMapper {
         this.buildOrCompilePatterns();
     }
 
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     @Override
     public MappingResult map(String mqttTopic) {
         for (MappingRule rule : this.rules) {

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
@@ -52,8 +52,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Integration test for MQTT bridge
  */
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 public class MqttBridgetIT {
-    private static final Logger logger = LoggerFactory.getLogger(MqttBridgetIT.class);
+    private static final Logger log = LoggerFactory.getLogger(MqttBridgetIT.class);
     private static final String MQTT_SERVER_HOST = "localhost";
     private static final int MQTT_SERVER_PORT = 1883;
     private static final String MQTT_SERVER_URI = "tcp://" + MQTT_SERVER_HOST + ":" + MQTT_SERVER_PORT;
@@ -76,7 +77,7 @@ public class MqttBridgetIT {
             kafkaContainer.start();
             kafkaBootstrapServers = kafkaContainer.getBootstrapServers();
         } catch (Exception e) {
-            logger.error("Exception occurred", e);
+            log.error("Exception occurred", e);
             throw e;
         }
 
@@ -164,12 +165,12 @@ public class MqttBridgetIT {
                 assertThat("The client should be connected",
                         client.isConnected(), is(true));
             } catch (MqttException e) {
-                logger.error("Exception occurred", e);
+                log.error("Exception occurred", e);
             } finally {
                 try {
                     client.disconnect();
                 } catch (MqttException e) {
-                    logger.error("Exception occurred", e);
+                    log.error("Exception occurred", e);
                 }
             }
         });

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigRetrieverTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigRetrieverTest.java
@@ -53,7 +53,7 @@ public class ConfigRetrieverTest {
      */
     @Test
     public void testApplicationPropertiesFileNotExists()  {
-        Exception fileNotFoundException = assertThrows(FileNotFoundException.class, ()-> ConfigRetriever.getConfig("not-exists-application.properties"));
+        Exception fileNotFoundException = assertThrows(FileNotFoundException.class, () -> ConfigRetriever.getConfig("not-exists-application.properties"));
 
         assertThat("File not found exception should be thrown",
                 fileNotFoundException.getMessage(), is("not-exists-application.properties (No such file or directory)"));

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigTest.java
@@ -6,7 +6,6 @@
 package io.strimzi.kafka.bridge.mqtt.config;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
This PR adds checkstyle and fixes code due to following warnings.

```shell
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServer.java:24:33: Name 'logger' must match pattern '(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)'. [ConstantName]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java:45:1: Class Fan-Out Complexity is 21 (max allowed is 20). [ClassFanOutComplexity]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java:47:33: Name 'logger' must match pattern '(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)'. [ConstantName]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/config/MqttConfig.java:63:29: '{' is not preceded with whitespace. [WhitespaceAround]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaRegexMapper.java:60:32: '->' is not preceded with whitespace. [WhitespaceAround]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/mapper/MqttKafkaSimpleMapper.java:47:5: Cyclomatic Complexity is 11 (max allowed is 10). [CyclomaticComplexity]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java:28:33: Name 'logger' must match pattern '(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)'. [ConstantName]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigRetrieverTest.java:56:87: '->' is not preceded with whitespace. [WhitespaceAround]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigTest.java:9:8: Unused import - org.apache.kafka.clients.consumer.ConsumerConfig. [UnusedImports]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java:55:1: Class Data Abstraction Coupling is 9 (max allowed is 7) classes [KafkaConsumer, MqttAsyncClient, MqttClient, MqttConnectOptions, MqttServer, NioEventLoopGroup, Random, StrimziKafkaContainer, StringDeserializer]. [ClassDataAbstractionCoupling]
[ERROR] /home/ppatiern/github/strimzi-mqtt-bridge/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java:56:33: Name 'logger' must match pattern '(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)'. [ConstantName]
```