### PR TITLE
Added missing spotbugs target in Makefile

### DIFF
--- a/Makefile.maven
+++ b/Makefile.maven
@@ -27,5 +27,5 @@ java_clean:
 	mvn clean
 
 .PHONY: spotbugs
-spotbugs: java_compile
+spotbugs:
 	mvn $(MVN_ARGS) spotbugs:check

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -25,3 +25,7 @@ java_install:
 java_clean:
 	echo "Cleaning Maven build ..."
 	mvn clean
+
+.PHONY: spotbugs
+spotbugs: java_compile
+	mvn $(MVN_ARGS) spotbugs:check


### PR DESCRIPTION
Trivial PR to add missing Makefile target for spotbugs which will be needed in the Azure pipeline.