### PR TITLE
Add an HTTP server for liveness and readiness probes

### DIFF
--- a/packaging/install/010-Service.yaml
+++ b/packaging/install/010-Service.yaml
@@ -12,3 +12,7 @@ spec:
         protocol: TCP
         port: 1883
         targetPort: 1883
+      - name: http
+        protocol: TCP
+        port: 8080
+        targetPort: 8080

--- a/packaging/install/020-ConfigMap.yaml
+++ b/packaging/install/020-ConfigMap.yaml
@@ -13,7 +13,7 @@ data:
     mqtt.host=0.0.0.0
     mqtt.port=1883
     #Apache Kafka common
-    kafka.bootstrap.servers=<kafka-bootstrap-servers>
+    kafka.bootstrap.servers=my-cluster-kafka-bootstrap:9092
   topic-mapping-rules.json: '[]'
   log4j2.properties: |
     name=MqttBridgeConfig

--- a/packaging/install/030-Deployment.yaml
+++ b/packaging/install/030-Deployment.yaml
@@ -23,6 +23,18 @@ spec:
           volumeMounts:
             - name: mqtt-bridge-config-volume
               mountPath: /opt/strimzi/config/
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
       volumes:
         - name: mqtt-bridge-config-volume
           configMap:

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <jackson.version>2.15.2</jackson.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <kafka.version>3.6.1</kafka.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <mockito.version>4.11.0</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
         <test-container.version>0.105.0</test-container.version>
@@ -88,6 +89,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/HttpServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/HttpServer.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.core;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Jetty based HTTP server used for health checks
+ */
+public class HttpServer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServer.class);
+    private static final int HTTP_PORT = 8080;
+
+    private final Server server;
+    private final Liveness liveness;
+    private final Readiness readiness;
+
+    /**
+     * Constructs the health check HTTP server.
+     *
+     * @param liveness  Callback used for the health check.
+     * @param readiness Callback used for the readiness check.
+     */
+    public HttpServer(Liveness liveness, Readiness readiness) {
+        this.liveness = liveness;
+        this.readiness = readiness;
+
+        this.server = new Server(HTTP_PORT);
+
+        ContextHandler readinessContext = new ContextHandler("/ready");
+        readinessContext.setHandler(new ReadyHandler());
+        readinessContext.setAllowNullPathInfo(true);
+
+        ContextHandler livenessContext = new ContextHandler("/healthy");
+        livenessContext.setHandler(new HealthyHandler());
+        livenessContext.setAllowNullPathInfo(true);
+
+        server.setHandler(new ContextHandlerCollection(readinessContext, livenessContext));
+    }
+
+    /**
+     * Start the HTTP server
+     */
+    public void start() {
+        try {
+            this.server.start();
+        } catch (Exception e)   {
+            LOGGER.error("Failed to start the HTTP server", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Stop the HTTP server
+     */
+    public void stop() {
+        try {
+            this.server.stop();
+        } catch (Exception e)   {
+            LOGGER.error("Failed to stop the HTTP server", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Handler responsible for the liveness check
+     */
+    class HealthyHandler extends AbstractHandler {
+
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+            if (liveness.isAlive()) {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            } else {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+            LOGGER.debug("Responding {} to GET /healthy", response.getStatus());
+            baseRequest.setHandled(true);
+        }
+    }
+
+    /**
+     * Handler responsible for the readiness check
+     */
+    class ReadyHandler extends AbstractHandler {
+
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+            if (readiness.isReady()) {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            } else {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+            LOGGER.debug("Responding {} to GET /ready", response.getStatus());
+            baseRequest.setHandled(true);
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/Liveness.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/Liveness.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.core;
+
+/**
+ * A liveness check implemented by an application and called by the
+ * {@link HttpServer} when handling a health check request.
+ */
+public interface Liveness {
+
+    /**
+     * @return  True when the application is alive, false otherwise.
+     */
+    boolean isAlive();
+}

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/Readiness.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/Readiness.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.mqtt.core;
+
+/**
+ * A readiness check implemented by an application and called by the
+ * {@link HttpServer} when handling a health check request.
+ */
+public interface Readiness {
+
+    /**
+     * @return  True when the application is ready, false otherwise
+     */
+    boolean isReady();
+}


### PR DESCRIPTION
This PR fixes #64
It adds and HTTP server for handling liveness and readiness probes.