### PR TITLE
Fixed release targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT_NAME ?= mqtt-bridge
 RELEASE_VERSION ?= latest
 
 .PHONY: all
-all: java_verify docker_build docker_push
+all: java_package docker_build docker_push
 
 .PHONY: clean
 clean: java_clean
@@ -22,6 +22,8 @@ next_version:
 
 .PHONY: release_prepare
 release_prepare:
+	echo "Update release.version to $(RELEASE_VERSION)"
+	echo $(shell echo $(RELEASE_VERSION) | tr a-z A-Z) > release.version
 	rm -rf ./strimzi-mqtt-bridge-$(RELEASE_VERSION)
 	rm -f ./strimzi-mqtt-bridge-$(RELEASE_VERSION).tar.gz
 	rm -f ./strimzi-mqtt-bridge-$(RELEASE_VERSION).zip
@@ -29,11 +31,8 @@ release_prepare:
 
 .PHONY: release_version
 release_version:
-	echo "Update release.version to $(RELEASE_VERSION)"
-	echo $(shell echo $(RELEASE_VERSION) | tr a-z A-Z) > release.version
-	echo "Update pom versions to $(RELEASE_VERSION)"
-	mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
-	mvn versions:commit
+	echo "Changing Docker image tags in install to :$(RELEASE_VERSION)"
+	$(FIND) ./packaging/install -name '*.yaml' -type f -exec $(SED) -i '/image: "\?quay.io\/strimzi\/[a-zA-Z0-9_.-]\+:[a-zA-Z0-9_.-]\+"\?/s/:[a-zA-Z0-9_.-]\+/:$(RELEASE_VERSION)/g' {} \;
 
 .PHONY: release_maven
 release_maven:
@@ -49,6 +48,3 @@ release_package:
 	zip -r ./strimzi-mqtt-bridge-$(RELEASE_VERSION).zip strimzi-mqtt-bridge-$(RELEASE_VERSION)/
 	rm -rf ./strimzi-mqtt-bridge-$(RELEASE_VERSION)
 	$(FIND) ./packaging/install/ -mindepth 1 -maxdepth 1 ! -name Makefile -type f,d -exec $(CP) -rv {} ./install/ \;
-
-.PHONY: release_package
-release_package: java_package


### PR DESCRIPTION
This PR fixes the release targets in the Makefile.
It was missing updating the Deployment file with the release version.
It's now more similar to the drain cleaner release process which provides installation files compared to the HTTP bridge which doesn't provide them.