### PR TITLE
Set the default MQTT host as 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A valid configuration file should look like this:
     bridge.id=my-bridge
     bridge.topic.default=default_topic
     # MQTT configuration
-    mqtt.host=localhost
+    mqtt.host=0.0.0.0
     mqtt.port=1883
     # Kafka configuration
     kafka.bootstrap.servers=localhost:9092
@@ -167,7 +167,7 @@ The following table describes the configuration properties defined above.
 |-------------------------|--------------------------------------------------------------|-------------------------|
 | bridge.id               | ID of the bridge                                             | null/undefined          |
 | bridge.topic.default    | Topic to be used if no matches with any mapping rules        | messages_default        |
-| mqtt.host               | Host address of the MQTT server                              | localhost               |
+| mqtt.host               | Host address of the MQTT server                              | 0.0.0.0                 |
 | mqtt.port               | Port number of the MQTT server                               | 1883                    |
 | kafka.bootstrap.servers | Bootstrap servers for Apache Kafka                           | localhost:9092          |
 | kafka.producer.*        | Any Kafka producer configuration (i.e. acks, linger.ms, ...) | Kafka producer defaults |

--- a/config/application.properties
+++ b/config/application.properties
@@ -2,7 +2,7 @@
 bridge.id=my-bridge
 bridge.topic.default=default_topic
 #MQTT server common
-mqtt.host=localhost
+mqtt.host=0.0.0.0
 mqtt.port=1883
 
 #Apache Kafka common

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
@@ -55,7 +55,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 public class MqttBridgetIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttBridgetIT.class);
-    private static final String MQTT_SERVER_HOST = "localhost";
+    private static final String MQTT_SERVER_HOST = "0.0.0.0";
     private static final int MQTT_SERVER_PORT = 1883;
     private static final String MQTT_SERVER_URI = "tcp://" + MQTT_SERVER_HOST + ":" + MQTT_SERVER_PORT;
     private static final String KAFKA_TOPIC = "devices_bluetooth_data";

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigRetrieverTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/config/ConfigRetrieverTest.java
@@ -38,8 +38,8 @@ public class ConfigRetrieverTest {
         // Mqtt server config related tests
         assertThat("There should be 2 related mqtt server config parameters",
                 bridgeConfig.getMqttConfig().getConfig().size(), is(2));
-        assertThat("Mqtt server host should be 'localhost'",
-                bridgeConfig.getMqttConfig().getHost(), is("localhost"));
+        assertThat("Mqtt server host should be '0.0.0.0'",
+                bridgeConfig.getMqttConfig().getHost(), is("0.0.0.0"));
         assertThat("Mqtt server port should be '1883'",
                 bridgeConfig.getMqttConfig().getPort(), is(1883));
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,7 +2,7 @@
 bridge.id=my-bridge
 bridge.topic.default=default_topic
 #MQTT server common
-mqtt.host=localhost
+mqtt.host=0.0.0.0
 mqtt.port=1883
 
 #Apache Kafka common


### PR DESCRIPTION
This PR fixes the default MQTT host to be `0.0.0.0` instead of `localhost` in the configuration files, doc and tests.
It aligns with what we have with the HTTP bridge as well as avoid users mistakes to have it listening on 127.0.0.1 by default and then not able to send request to the actual IP (i.e. when using an Nginx proxy).