### PR TITLE
Use log4j2 instead of slf4j for our own loggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.1.100.Final</netty.version>
         <log4j.version>2.17.2</log4j.version>
-        <slf4j.version>1.7.36</slf4j.version>
         <junit.version>5.8.2</junit.version>
         <jackson.version>2.15.3</jackson.version>
         <commons-cli.version>1.5.0</commons-cli.version>
@@ -64,11 +63,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/Main.java
@@ -16,15 +16,15 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 public class Main {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+    private static final Logger LOGGER = LogManager.getLogger(Main.class);
     private static final String CONFIG_FILE_OPTION = "config-file";
     private static final String MAPPING_RULES_FILE_OPTION = "mapping-rules";
 

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/HttpServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/HttpServer.java
@@ -9,8 +9,8 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class HttpServer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServer.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpServer.class);
     private static final int HTTP_PORT = 8080;
 
     private final Server server;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServer.java
@@ -14,14 +14,14 @@ import io.netty.handler.logging.LoggingHandler;
 import io.strimzi.kafka.bridge.mqtt.config.BridgeConfig;
 import io.strimzi.kafka.bridge.mqtt.config.MqttConfig;
 import io.strimzi.kafka.bridge.mqtt.kafka.KafkaBridgeProducer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents the MqttServer component.
  */
 public class MqttServer implements Liveness, Readiness {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MqttServer.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttServer.class);
     private final EventLoopGroup masterGroup;
     private final EventLoopGroup workerGroup;
     private final ServerBootstrap serverBootstrap;

--- a/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
+++ b/src/main/java/io/strimzi/kafka/bridge/mqtt/core/MqttServerHandler.java
@@ -25,8 +25,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -45,7 +45,7 @@ import static io.netty.channel.ChannelHandler.Sharable;
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @Sharable
 public class MqttServerHandler extends SimpleChannelInboundHandler<MqttMessage> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MqttServerHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttServerHandler.class);
     private final KafkaBridgeProducer kafkaBridgeProducer;
     private MqttKafkaMapper mqttKafkaMapper;
 

--- a/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/mqtt/MqttBridgetIT.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -54,7 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 public class MqttBridgetIT {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MqttBridgetIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(MqttBridgetIT.class);
     private static final String MQTT_SERVER_HOST = "0.0.0.0";
     private static final int MQTT_SERVER_PORT = 1883;
     private static final String MQTT_SERVER_URI = "tcp://" + MQTT_SERVER_HOST + ":" + MQTT_SERVER_PORT;


### PR DESCRIPTION
As already done with the HTTP bridge https://github.com/strimzi/strimzi-kafka-bridge/pull/864, this PR moves from slf4j to log4j2 for our own loggers.