### PR TITLE
Bumped Kafka 4.0.0 and Netty 4.1.118.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.115.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <log4j.version>2.17.2</log4j.version>
         <junit.version>5.8.2</junit.version>
         <jackson.version>2.15.3</jackson.version>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <kafka.version>3.9.0</kafka.version>
+        <kafka.version>4.0.0</kafka.version>
         <jetty.version>9.4.55.v20240627</jetty.version>
         <mockito.version>4.11.0</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Trivial PR to bump Kafka 4.0.0 and Netty 4.1.118.Final.