### PR TITLE
Fix naming of artifacts for CVE/Release workflows

### DIFF
--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Pull Java artifacts from GHCR
         run: |
-          oras pull ghcr.io/${{ env.REPOSITORY }}/bridge-binaries:${{ env.TAG }}
+          oras pull ghcr.io/${{ env.REPOSITORY }}/binaries-mqtt-bridge:${{ env.TAG }}
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"
@@ -48,8 +48,8 @@ jobs:
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v5
         with:
-          name: mqtt-bridge-binaries.tar
-          path: mqtt-bridge-binaries.tar
+          name: binaries-mqtt-bridge.tar
+          path: binaries-mqtt-bridge.tar
 
   build-containers:
     name: Build Containers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Download bridge binaries from source build
         uses: actions/download-artifact@v7
         with:
-          name: mqtt-bridge-binaries.tar
+          name: binaries-mqtt-bridge.tar
           run-id: ${{ inputs.sourceBuildRunId }}
           github-token: ${{ github.token }}
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Push Java artifacts to GHCR
         run: |
-          oras push ghcr.io/${{ env.REPOSITORY }}/bridge-binaries:${{ env.TAG }} mqtt-bridge-binaries.tar:application/x-tar
+          oras push ghcr.io/${{ env.REPOSITORY }}/binaries-mqtt-bridge:${{ env.TAG }} binaries-mqtt-bridge.tar:application/x-tar
         env:
           TAG: ${{ inputs.releaseVersion }}-${{ inputs.sourceBuildRunId }}
           REPOSITORY: "strimzi"


### PR DESCRIPTION
During 1st release of Bridge we found out that we had wrong names for artifacts within CVE and release workflows. This PR fixes it in strimzi-mqtt-bridge repo.