### PR TITLE
Bumped log4j version to address CVE-2026-49844

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.2.16.Final</netty.version>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <junit.version>5.8.2</junit.version>
         <jackson.version>2.22.1</jackson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Trivial PR to bump log4j version to address [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844)