### PR TITLE
Organize pom dependencies in groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,29 +18,37 @@
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Maven plugin versions -->
+        <maven.surefire.version>3.5.4</maven.surefire.version>
+        <maven.failsafe.version>3.5.4</maven.failsafe.version>
+        <maven.assembly.version>3.4.2</maven.assembly.version>
+        <maven.jar.version>3.3.0</maven.jar.version>
+        <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
+        <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
+
+        <!-- Build tools -->
+        <checkstyle.version>10.18.1</checkstyle.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
+
+        <!-- Runtime dependencies -->
         <netty.version>4.2.17.Final</netty.version>
         <log4j.version>2.25.5</log4j.version>
-        <junit.version>6.0.0</junit.version>
         <jackson.version>2.22.1</jackson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <kafka.version>4.3.1</kafka.version>
         <jetty.version>9.4.56.v20240826</jetty.version>
+
+        <!-- Test only dependencies -->
+        <junit.version>6.0.0</junit.version>
         <mockito.version>5.21.0</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
         <test-container.version>0.116.0</test-container.version>
         <eclipse-paho.version>1.2.5</eclipse-paho.version>
-        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <maven.assembly.version>3.4.2</maven.assembly.version>
-        <spotbugs.version>4.7.3</spotbugs.version>
-        <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
-        <maven.checkstyle.version>3.5.0</maven.checkstyle.version>
-        <checkstyle.version>10.18.1</checkstyle.version>
     </properties>
 
     <dependencies>
@@ -142,12 +150,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
+                <version>${maven.surefire.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven-failsafe-plugin.version}</version>
+                <version>${maven.failsafe.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -160,7 +168,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven-jar-plugin.version}</version>
+                <version>${maven.jar.version}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -181,6 +189,7 @@
                         </goals>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>


### PR DESCRIPTION
This PR re-organize the dependencies within the pom.xml by grouping them as we already have in the Strimzi operator and HTTP bridge.
It also fixes a warning about files long name (as it's already fixed in the HTTP bridge).