### PR TITLE
Bumped Jackson for CVEs fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <!-- Runtime dependencies -->
         <netty.version>4.2.17.Final</netty.version>
         <log4j.version>2.25.5</log4j.version>
-        <jackson.version>2.22.1</jackson.version>
+        <jackson.version>2.22.2</jackson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <kafka.version>4.3.1</kafka.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps Jackson to 2.22.2 to fix some CVEs.

### Checklist

- [x] Make sure all tests pass
